### PR TITLE
Document Docker prerequisites and troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,21 @@ phlag/
 
 ## ⚙️ Installation
 
-Before starting, confirm your Docker Desktop or Engine meets the minimum versions documented in [`doc/docker-troubleshooting.md`](./doc/docker-troubleshooting.md). The guide also covers common fixes if the Compose stack fails to start.
+### Prerequisites
+
+- Docker Desktop 4.32.0+ (Engine 26.1.1, Compose 2.27+) on macOS or Windows with virtualization enabled (HyperKit on Apple Silicon, WSL 2 on Windows).
+- Docker Engine 26.0.0+ with the Compose plugin 2.27+ on Linux; install the `docker-compose-plugin` package provided by your distribution.
+- BuildKit enabled for modern Dockerfile syntax. Add the following to `~/.docker/config.json` (see Docker documentation) or export `DOCKER_BUILDKIT=1` before building:
+
+    ```json
+    {
+        "features": {
+            "buildkit": true
+        }
+    }
+    ```
+
+Need more detail? The troubleshooting guide in [`doc/docker-troubleshooting.md`](./doc/docker-troubleshooting.md) covers version checks, disk space tips, and recovery steps.
 
 ### 1. Clone & install dependencies
 

--- a/doc/docker-troubleshooting.md
+++ b/doc/docker-troubleshooting.md
@@ -20,6 +20,13 @@ docker compose version --short
 
 Both reported versions should meet or exceed the minimums above. If they do not, upgrade Docker Desktop or your Engine/Compose packages.
 
+## Host Requirements Checklist
+
+- Hardware virtualization must be enabled in firmware (BIOS/UEFI) so Docker Desktop can run HyperKit/Hyper-V/WSL 2.
+- Allocate at least 4 CPU cores and 4 GB RAM to Docker Desktop; heavier migrations benefit from 6 GB+.
+- Keep 6 GB of free disk space for images, volumes, and build cache (`docker system df` reports usage).
+- On Windows, confirm WSL 2 is installed and set as the default backend prior to starting the stack.
+
 ## Fast Health Checks
 
 - `docker info` — confirms the engine is running and reports the virtualization backend (WSL 2, HyperKit, etc.).
@@ -36,7 +43,16 @@ Both reported versions should meet or exceed the minimums above. If they do not,
 
 **Fix**
 1. Upgrade to the minimum versions listed above.
-2. Ensure BuildKit is enabled by exporting `DOCKER_BUILDKIT=1` or setting `"features": { "buildkit": true }` in `~/.docker/config.json`.
+2. Ensure BuildKit is enabled by exporting `DOCKER_BUILDKIT=1` or configuring it permanently via `~/.docker/config.json`:
+
+    ```json
+    {
+        "features": {
+            "buildkit": true
+        }
+    }
+    ```
+
 3. Retry `docker compose build app`.
 
 ### `docker compose up` fails because port 80 is already in use


### PR DESCRIPTION
## Summary
- add explicit Docker Desktop/Engine minimum versions to the README prerequisites
- reference the BuildKit configuration snippet and cross-link the troubleshooting guide
- expand the troubleshooting doc with host hardware checks and reusable BuildKit fix steps

## Testing
- not run (docs-only)

Closes #21.