### PR TITLE
Document Docker worker scaling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The service is intended for local demonstrations:
 
 When you are finished experimenting, shut everything down with `docker compose down`.
 
+Need to scale HTTP workers or spawn dedicated CLI worker containers? Follow the patterns documented in `doc/docker-worker-scaling.md`.
+
 ---
 
 ## 🧭 Development Workflow

--- a/doc/12-factor-compliance.md
+++ b/doc/12-factor-compliance.md
@@ -45,9 +45,8 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 
 ## VIII. Concurrency
 
--   Horizontal scalability for demos is manual—run additional PHP processes if necessary.
+-   Horizontal scalability for demos is manual—run additional PHP processes if necessary (see `doc/docker-worker-scaling.md` for Docker Compose scaling patterns).
 -   PostgreSQL and Redis containers can be reconfigured with Docker Compose overrides when load testing locally.
--   **Action:** capture guidance for running multiple worker processes against the same containers.
 
 ## IX. Disposability
 
@@ -78,4 +77,5 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 1. Ensure new Laravel configuration reads from environment variables; avoid embedding defaults that vary per environment.
 2. Provide guidance for building optional Docker images if teammates want to share artifacts.
 3. ✅ Capture Docker version/system requirements and troubleshooting steps for local contributors (see `doc/docker-troubleshooting.md`).
-4. ✅ Document helper scripts for running one-off admin tasks while Docker Compose services are detached.
+4. ✅ Capture worker scaling guidance for Docker Compose (see `doc/docker-worker-scaling.md`).
+5. ✅ Document helper scripts for running one-off admin tasks while Docker Compose services are detached.

--- a/doc/docker-troubleshooting.md
+++ b/doc/docker-troubleshooting.md
@@ -24,6 +24,7 @@ Both reported versions should meet or exceed the minimums above. If they do not,
 
 - Hardware virtualization must be enabled in firmware (BIOS/UEFI) so Docker Desktop can run HyperKit/Hyper-V/WSL 2.
 - Allocate at least 4 CPU cores and 4 GB RAM to Docker Desktop; heavier migrations benefit from 6 GB+.
+- Budget additional CPU (6 cores) and memory (8 GB+) if you plan to scale PHP workers; see `doc/docker-worker-scaling.md` for guidance.
 - Keep 6 GB of free disk space for images, volumes, and build cache (`docker system df` reports usage).
 - On Windows, confirm WSL 2 is installed and set as the default backend prior to starting the stack.
 

--- a/doc/docker-worker-scaling.md
+++ b/doc/docker-worker-scaling.md
@@ -1,0 +1,97 @@
+# Running Multiple PHP Workers with Docker Compose
+
+Date: 2025-10-11
+
+This guide explains how to run additional PHP worker processes alongside the default `app` service defined in `compose.yaml`. Use it when you want to exercise the 12-Factor “Concurrency” principle locally—whether that means scaling HTTP handlers for heavy traffic demos or running long-lived CLI workers that share the same PostgreSQL and Redis backing services.
+
+## Prerequisites
+
+- The baseline stack (`docker compose up -d --build`) is running and healthy.
+- `.env.local` contains the credentials referenced by `compose.yaml`, and you have exported them in your shell (`set -a; source .env.local; set +a`) before launching helper scripts.
+
+Verify that all services are running before scaling:
+
+```bash
+docker compose ps --status=running
+docker compose top
+```
+
+Both commands should list the `app`, `postgres`, and `redis` processes (see the Docker Compose command reference for details on `ps` and `top` output formatting).
+
+## Scaling Additional HTTP Workers
+
+The `app` service uses PHP’s built-in server bound to port 80. You can ask Docker Compose to launch extra containers for this service:
+
+```bash
+docker compose up -d --scale app=3
+```
+
+Key notes:
+
+- Only one container can publish port `80` on the host. Docker Compose keeps the first replica exposed and attaches the remaining replicas to the internal `phlag` network. For local load-testing, target the service name (`http://app:80`) from another container (for example, `docker compose run --rm app curl http://app:80/health`).
+- Keep an eye on resource usage with `docker stats app` and adjust Docker Desktop’s CPU/RAM allocation if requests begin to queue.
+- When you are done, scale back down with `docker compose up -d --scale app=1` or stop the replicas via `docker compose stop app`.
+
+## Running Dedicated CLI Worker Containers
+
+For long-lived CLI workers (queue consumers, cache warmers, schedulers), define a lightweight override file—`compose.workers.yaml`—next to the primary `compose.yaml`:
+
+```yaml
+# compose.workers.yaml
+services:
+  worker:
+    build:
+      context: .
+      dockerfile: docker/app/Dockerfile
+    command: php phlag <worker-command>
+    env_file:
+      - .env.local
+    environment:
+      APP_ENV: ${APP_ENV:-local}
+    depends_on:
+      - postgres
+      - redis
+    networks:
+      - phlag
+    profiles:
+      - workers
+```
+
+Replace `<worker-command>` with the long-running Laravel Zero command you want to execute (for example, a future `php phlag queue:work --sleep=1 --tries=3` implementation). The worker service intentionally omits any `ports` mapping because it communicates only with internal services.
+
+Launch one or more worker containers with:
+
+```bash
+docker compose -f compose.yaml -f compose.workers.yaml up -d --build worker
+docker compose -f compose.yaml -f compose.workers.yaml up -d --scale worker=3
+```
+
+Inspect their status and logs as they run:
+
+```bash
+docker compose -f compose.yaml -f compose.workers.yaml ps worker
+docker compose -f compose.yaml -f compose.workers.yaml logs -f worker
+```
+
+Stop and remove the workers without touching the primary stack:
+
+```bash
+docker compose -f compose.yaml -f compose.workers.yaml stop worker
+docker compose -f compose.yaml -f compose.workers.yaml rm -f worker
+```
+
+## Resource Planning
+
+- **CPU & RAM:** Each PHP process competes for the Docker Desktop allocation. Increase the CPU (4→6 cores) and memory (4→8 GB) sliders when running more than two worker containers.
+- **Database connections:** Confirm that `POSTGRES_MAX_CONNECTIONS` (set via `.env.local`) leaves headroom for the new workers; Laravel/PDO pools will open additional connections as they scale.
+- **Redis throughput:** Monitor `docker compose logs redis` for `BUSY` or connection warnings. If caching becomes saturated, raise Redis’ memory limits or reduce worker concurrency.
+
+Revisit these settings whenever you introduce new worker types so that local demos mimic your intended production scaling story.
+
+## Cleanup Checklist
+
+- Scale services back to a single instance (`docker compose up -d --scale app=1`).
+- Remove optional worker containers (`docker compose -f compose.yaml -f compose.workers.yaml down`).
+- Run `docker compose ps --all` to ensure no orphaned worker containers remain.
+
+Document any new profiles or override files in ADRs when they become a permanent part of the stack.


### PR DESCRIPTION
## Summary
- add a dedicated guide for scaling PHP workers with Docker Compose
- link the new guide from the 12-factor concurrency checklist, README, and troubleshooting guide
- close out the concurrency action item by advising on resource planning for scaled workers

Fixes #34

## Testing
- not run (documentation-only change)
