### PR TITLE
Add Docker health checks and PHP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ When you are finished experimenting, shut everything down with `docker compose d
 
 Need to scale HTTP workers or spawn dedicated CLI worker containers? Follow the patterns documented in `doc/docker-worker-scaling.md`.
 
+### Container runtime details
+
+-   The `app` image pre-installs the PHP extensions required by Laravel + Redis (`pdo_pgsql`, `zip`, and `redis`) and provides `curl` for internal health probes.
+-   Docker Compose health checks monitor the `app`, `postgres`, and `redis` services; the application container now waits for the data stores to become healthy before starting its HTTP server.
+
 ---
 
 ## 🧭 Development Workflow

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,8 +7,10 @@ services:
       dockerfile: docker/app/Dockerfile
     command: php -S 0.0.0.0:80 -t public public/index.php
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env.local
     environment:
@@ -17,6 +19,12 @@ services:
       - "80:80"
     volumes:
       - ./:/app
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:80/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - phlag
 
@@ -29,6 +37,12 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     networks:
       - phlag
 
@@ -36,6 +50,12 @@ services:
     image: redis:8
     restart: unless-stopped
     command: redis-server --save "" --appendonly no
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     networks:
       - phlag
 

--- a/doc/12-factor-compliance.md
+++ b/doc/12-factor-compliance.md
@@ -12,6 +12,7 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 ## II. Dependencies
 
 -   PHP dependencies are explicitly declared in `composer.json` and installed via Composer.
+-   The `app` container image installs required PHP extensions (`pdo_pgsql`, `zip`, `redis`) so runtime binaries match the code’s expectations.
 -   Container images built in CI ensure consistent dependency versions across environments.
 
 ## III. Config
@@ -51,6 +52,7 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 ## IX. Disposability
 
 -   Containers are stateless; stopping Docker Compose tears services down cleanly while preserving volumes if configured.
+-   Docker Compose health checks gate readiness for `app`, `postgres`, and `redis`, improving shutdown/startup signalling and reducing flapping during restarts.
 -   CI pipelines ensure rapid spin up of new instances from immutable images.
 
 ## X. Dev/Prod Parity

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -3,9 +3,11 @@
 FROM php:8.4-cli
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git unzip libpq-dev libzip-dev \
-    && docker-php-ext-install pdo_pgsql \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends curl git unzip libpq-dev libzip-dev \
+    && docker-php-ext-install pdo_pgsql zip \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && rm -rf /var/lib/apt/lists/* /tmp/pear
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install the PHP extensions and curl the app container needs for Postgres, Redis, and health probes
- add Docker Compose health checks for app, postgres, and redis while waiting on healthy dependencies before booting the HTTP server
- document the runtime updates in the README and 12-factor compliance checklist

## Issue
- Closes #23

## Testing
- composer test