### PR TITLE
Configure Compose stdout logging with rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ This launches three services within an isolated Docker network:
 
 Only the application’s port 80 is published to your LAN (`http://localhost/` by default).
 
+Logs remain on stdout; tail them with `docker compose logs -f` when debugging. The Compose file configures the `json-file` driver with `max-size=10m` and `max-file=5`, so each container keeps a rotating local buffer without requiring extra volumes.
+
 ### 4. Run migrations and seed data
 
 Execute CLI commands inside the `app` container so they share networking and environment context. Helper scripts wrap

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,11 @@ services:
       - "80:80"
     volumes:
       - ./:/app
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:80/ || exit 1"]
       interval: 30s
@@ -37,6 +42,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 30s
@@ -50,6 +60,11 @@ services:
     image: redis:8
     restart: unless-stopped
     command: redis-server --save "" --appendonly no
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s

--- a/doc/12-factor-compliance.md
+++ b/doc/12-factor-compliance.md
@@ -64,7 +64,7 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 ## XI. Logs
 
 -   Application logs written to stdout; developers inspect them via `docker compose logs` or `docker compose logs app`.
--   **Action:** decide whether to persist logs to disk volumes for longer local analysis.
+-   Docker Compose uses the `json-file` logging driver with rotation (`max-size=10m`, `max-file=5`) so containers stream logs while retaining a small local buffer without bespoke volumes.
 
 ## XII. Admin Processes
 


### PR DESCRIPTION
## Summary
- configure the app, postgres, and redis services to use the json-file logging driver with 10MiB/5-file rotation
- record the stdout-with-rotation approach in the 12-factor compliance checklist
- document how to follow logs and the retention settings in the README

## Testing
- not run (local configuration/documentation change only)