### PR TITLE
Add schema overview ER diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ curl --request GET \
 
 ## 🗂️ Architecture references
 
+-   [`doc/schema-overview.md`](./doc/schema-overview.md) — Entity relationship diagram for projects, environments, flags, evaluations, and audit events.
 -   [`doc/adr/0010-manage-jwt-signing-keys.md`](./doc/adr/0010-manage-jwt-signing-keys.md) — RSA signing keys with fallback HMAC mode and rotation workflow.
 -   [`doc/adr/0011-invalidate-redis-caches.md`](./doc/adr/0011-invalidate-redis-caches.md) — Redis cache key structure, TTLs, and pub/sub invalidation channel.
 -   [`doc/adr/0012-persist-audit-events-in-postgres.md`](./doc/adr/0012-persist-audit-events-in-postgres.md) — Audit event schema, access patterns, and retention policy.

--- a/doc/schema-overview.md
+++ b/doc/schema-overview.md
@@ -1,0 +1,99 @@
+# Schema Overview
+
+Date: 2025-10-11
+
+This document captures the current relational model for Phlag based on the Laravel migrations in `database/migrations`. Use it to orient yourself when extending the domain or crafting new database queries.
+
+```mermaid
+erDiagram
+    PROJECTS {
+        uuid id PK
+        string key UK
+        string name
+        text description
+        json metadata
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    ENVIRONMENTS {
+        uuid id PK
+        uuid project_id FK
+        string key
+        string name
+        text description
+        boolean is_default
+        json metadata
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    FLAGS {
+        uuid id PK
+        uuid project_id FK
+        string key
+        string name
+        text description
+        boolean is_enabled
+        json variants
+        json rules
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    EVALUATIONS {
+        uuid id PK
+        uuid project_id FK
+        uuid environment_id FK
+        uuid flag_id FK
+        string flag_key
+        string variant
+        string evaluation_reason
+        string user_identifier
+        json request_context
+        json evaluation_payload
+        timestamptz evaluated_at
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    AUDIT_EVENTS {
+        uuid id PK
+        uuid project_id FK
+        uuid environment_id FK
+        uuid flag_id FK
+        string action
+        string target_type
+        uuid target_id
+        string actor_type
+        string actor_identifier
+        json changes
+        json context
+        timestamptz occurred_at
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    PROJECTS ||--o{ ENVIRONMENTS : hosts
+    PROJECTS ||--o{ FLAGS : owns
+    PROJECTS ||--o{ EVALUATIONS : records
+    ENVIRONMENTS ||--o{ EVALUATIONS : scopes
+    FLAGS ||--o{ EVALUATIONS : produces
+    PROJECTS ||--o{ AUDIT_EVENTS : audits
+    ENVIRONMENTS }o..o{ AUDIT_EVENTS : contextualizes
+    FLAGS }o..o{ AUDIT_EVENTS : touches
+```
+
+## Relationship Notes
+
+- `environments`, `flags`, and `evaluations` cascade on project deletion; derived records disappear with the parent project.
+- Evaluations belong to a single environment/flag pair and capture request metadata for debugging.
+- Audit events may reference a project, environment, and/or flag (all optional) to describe the scope of the change.
+
+## Keeping the Diagram Updated
+
+1. Review new or modified migrations under `database/migrations`.
+2. Update the entity attributes or relationships in the Mermaid definition above.
+3. Preview the diagram locally (e.g., VS Code Markdown preview or Mermaid Live Editor) before committing.
+
+When introducing new tables, add them to the diagram and describe any cascading behavior or key constraints so future contributors can reason about the schema quickly.


### PR DESCRIPTION
## Summary
- add a Mermaid-based ER diagram describing projects, environments, flags, evaluations, and audit events
- capture relationship notes and update guidance in `doc/schema-overview.md`
- reference the schema overview from the README architecture section so onboarding materials point to it

## Testing
- not run (documentation-only)

Resolves #26.