### PR TITLE
Add helper scripts for cache warm and audit tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,22 @@ The command drops and recreates the schema before seeding so you always have the
 Database seeding completed.
 ```
 
+### Example: Warm flag caches for a project
+
+```bash
+./scripts/app-cache-warm demo-project production
+```
+
+Provide the project and environment keys to repopulate Redis after changing flag rules. Pass additional options (for example, `--daemon`) and they are forwarded to the underlying `cache:warm` command.
+
+### Example: Tail audit events
+
+```bash
+./scripts/app-audit-tail --project=demo-project --env=production
+```
+
+Use the helper to follow recent audit entries without typing the full `docker compose exec` invocation. All flags are passed directly to the `audit:tail` CLI command.
+
 ### Example: Verify the CLI wiring inside the container
 
 Use the sample `app:hello` command to confirm you can execute Laravel Zero commands through the helper:

--- a/doc/12-factor-compliance.md
+++ b/doc/12-factor-compliance.md
@@ -69,7 +69,7 @@ This document tracks how the Phlag project aligns with the [12-Factor App](https
 ## XII. Admin Processes
 
 -   One-off tasks executed via Laravel Zero commands (`php phlag app:migrate`, etc.) inside the `app` container.
--   Documented helper scripts (`./scripts/app-cli`, `./scripts/app-migrate`, `./scripts/app-seed`) wrap `docker compose exec app ...`
+-   Documented helper scripts (`./scripts/app-cli`, `./scripts/app-migrate`, `./scripts/app-seed`, `./scripts/app-cache-warm`, `./scripts/app-audit-tail`) wrap `docker compose exec app ...`
     for detached scenarios.
 
 ---

--- a/scripts/app-audit-tail
+++ b/scripts/app-audit-tail
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/app-cli" audit:tail "$@"

--- a/scripts/app-cache-warm
+++ b/scripts/app-cache-warm
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $(basename "$0") <project-key> <environment-key> [options]" >&2
+    echo "Example: $(basename "$0") demo-project production --daemon" >&2
+    exit 1
+fi
+
+PROJECT="$1"
+ENVIRONMENT="$2"
+shift 2 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/app-cli" cache:warm "$PROJECT" "$ENVIRONMENT" "$@"


### PR DESCRIPTION
## Summary
- add scripts `app-cache-warm` and `app-audit-tail` that wrap the relevant Laravel Zero commands via `app-cli`
- document usage in the README, including examples for warming caches and tailing audit events
- update the 12-factor compliance notes to reference the expanded helper script set

## Testing
- not run (scripts and documentation only)

Resolves #12.