### PR TITLE
Add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,87 @@
+name: Docker Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (defaults to current commit SHA)"
+        required: false
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/phlag
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine tags
+        id: vars
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${{ github.event.inputs.tag }}" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="$(git rev-parse --short HEAD)"
+          fi
+
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "latest=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "latest=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Log in to GHCR (PAT)
+        if: ${{ secrets.GHCR_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Log in to GHCR (GitHub token)
+        if: ${{ secrets.GHCR_TOKEN == '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/app/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Push latest tag
+        if: steps.vars.outputs.latest == 'true'
+        run: |
+          docker tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag }}" "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🚦 Phlag - Feature Flag Service
 
+[![Docker Publish](https://github.com/danhenke/phlag/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/danhenke/phlag/actions/workflows/docker-publish.yml)
+
 A lightweight, developer-focused **Feature Flag & Remote Configuration API** built with **Laravel Zero**, **PostgreSQL**, and **Redis**. The project runs entirely on a local **Docker Compose** stack so you can experiment with feature flag workflows without provisioning any cloud infrastructure.
 
 Please refer to [`doc/adr`](./doc/adr) for [Architecture Decision Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (ADRs) and [`doc/12-factor-compliance.md`](./doc/12-factor-compliance.md) for the 12-Factor alignment checklist.
@@ -426,6 +428,14 @@ Need to scale HTTP workers or spawn dedicated CLI worker containers? Follow the 
 
 -   The `app` image pre-installs the PHP extensions required by Laravel + Redis (`pdo_pgsql`, `zip`, and `redis`) and provides `curl` for internal health probes.
 -   Docker Compose health checks monitor the `app`, `postgres`, and `redis` services; the application container now waits for the data stores to become healthy before starting its HTTP server.
+
+## 📦 Docker image workflow
+
+-   Build locally with `./scripts/docker-build-app` (defaults to tagging `phlag-app:local-<sha>` and `phlag-app:latest`).
+-   Publish to a registry with `./scripts/docker-publish-app --image ghcr.io/<owner>/phlag --tag <version> [--latest]`.
+-   CI workflow `.github/workflows/docker-publish.yml` publishes images to GHCR. Optionally configure repository secrets:
+    - `GHCR_TOKEN` — personal access token (owned by `${{ github.repository_owner }}` or a dedicated bot account) with `write:packages`. When absent, the workflow falls back to the built-in `GITHUB_TOKEN`.
+-   Detailed sharing instructions live in [`doc/docker-image-sharing.md`](./doc/docker-image-sharing.md).
 
 ---
 

--- a/scripts/docker-build-app
+++ b/scripts/docker-build-app
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: docker-build-app [--tag <tag>] [--platform <platform>]
+
+Builds the Phlag application image using docker buildx.
+- If no tag is provided, defaults to phlag-app:local-<git-sha>.
+- The resulting image is also tagged as phlag-app:latest for local compose runs.
+
+Examples:
+  ./scripts/docker-build-app
+  ./scripts/docker-build-app --tag phlag-app:local-main --platform linux/amd64
+USAGE
+}
+
+TAG=""
+PLATFORM="linux/amd64"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)
+            TAG="$2"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$TAG" ]]; then
+    GIT_SHA="$(git rev-parse --short HEAD)"
+    TAG="phlag-app:local-${GIT_SHA}"
+fi
+
+echo "Building docker image with tag: ${TAG} (platform: ${PLATFORM})"
+
+docker buildx build \
+    --load \
+    --platform "${PLATFORM}" \
+    -t "${TAG}" \
+    -t phlag-app:latest \
+    -f docker/app/Dockerfile \
+    .
+
+echo "Image available locally as ${TAG} and phlag-app:latest"

--- a/scripts/docker-publish-app
+++ b/scripts/docker-publish-app
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: docker-publish-app --image <registry/repo> --tag <tag> [--source-tag <local-tag>] [--latest]
+
+Publishes the Phlag application image to a remote registry.
+
+Required arguments:
+  --image       Fully qualified image name (e.g. ghcr.io/example/phlag)
+  --tag         Tag to publish (e.g. 1.0.0 or commit sha)
+
+Optional arguments:
+  --source-tag  Local tag to push (defaults to phlag-app:latest)
+  --latest      Also push the 'latest' tag to the remote image
+
+Examples:
+  REGISTRY_IMAGE=ghcr.io/example/phlag ./scripts/docker-publish-app --image "$REGISTRY_IMAGE" --tag 1.2.3
+  ./scripts/docker-publish-app --image ghcr.io/example/phlag --tag $(git rev-parse --short HEAD) --latest
+USAGE
+}
+
+REMOTE_IMAGE=""
+PUBLISH_TAG=""
+SOURCE_TAG="phlag-app:latest"
+PUSH_LATEST="false"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            REMOTE_IMAGE="$2"
+            shift 2
+            ;;
+        --tag)
+            PUBLISH_TAG="$2"
+            shift 2
+            ;;
+        --source-tag)
+            SOURCE_TAG="$2"
+            shift 2
+            ;;
+        --latest)
+            PUSH_LATEST="true"
+            shift 1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$REMOTE_IMAGE" || -z "$PUBLISH_TAG" ]]; then
+    echo "Missing required arguments." >&2
+    usage
+    exit 1
+fi
+
+TARGET="${REMOTE_IMAGE}:${PUBLISH_TAG}"
+
+echo "Tagging ${SOURCE_TAG} as ${TARGET}"
+docker tag "${SOURCE_TAG}" "${TARGET}"
+
+echo "Pushing ${TARGET}"
+docker push "${TARGET}"
+
+if [[ "${PUSH_LATEST}" == "true" ]]; then
+    LATEST_TAG="${REMOTE_IMAGE}:latest"
+    echo "Tagging ${SOURCE_TAG} as ${LATEST_TAG}"
+    docker tag "${SOURCE_TAG}" "${LATEST_TAG}"
+    echo "Pushing ${LATEST_TAG}"
+    docker push "${LATEST_TAG}"
+fi
+
+echo "Publish complete"


### PR DESCRIPTION
## Summary
- add helper scripts `docker-build-app` and `docker-publish-app` for consistent local image builds and registry pushes
- introduce a Docker Publish GitHub Actions workflow that builds/pushes the app image to GHCR on manual dispatch or version tag pushes
- document the workflow in the README and expand the Docker image sharing guide with script usage and automation notes

## Testing
- not run (scripts/docs/workflow)

Resolves #19.