### PR TITLE
Refactor Dockerfile around PHAR runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 doc
 tests
 vendor
+builds
 node_modules
 docker-compose.yml
 docker-compose.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/builds
 /.idea
 /.vscode
 /.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN composer install \
     --optimize-autoloader \
     --classmap-authoritative
 
-FROM php:8.4-cli
+FROM php:8.4-cli AS base
 
-LABEL org.opencontainers.image.description="Phlag feature flag and remote configuration service"
+ARG SOURCE_DATE_EPOCH
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl git unzip libpq-dev libzip-dev \
@@ -28,11 +28,30 @@ RUN apt-get update \
 
 WORKDIR /app
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-COPY . .
-COPY --from=vendor /app/vendor ./vendor
+FROM base AS builder
 
-RUN composer dump-autoload --optimize --classmap-authoritative
+ARG SOURCE_DATE_EPOCH
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=vendor /app/vendor ./vendor
+COPY . .
+
+RUN composer dump-autoload --optimize --classmap-authoritative \
+    && php phlag app:build phlag
+
+FROM base AS runtime
+
+ARG SOURCE_DATE_EPOCH
+
+LABEL org.opencontainers.image.description="Phlag feature flag and remote configuration service"
+
+ENV PHLAG_PHAR=/app/phlag
+
+COPY public ./public
+COPY --from=builder /app/builds/phlag ./phlag
+
+RUN chmod +x /app/phlag \
+    && ln -sf /app/phlag /usr/local/bin/phlag
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Need to scale HTTP workers or spawn dedicated CLI worker containers? Follow the 
 -   Build locally with `./scripts/docker-build-app` (defaults to tagging `phlag-app:local-<sha>` and `phlag-app:latest`).
 -   Publish to a registry with `./scripts/docker-publish-app --image ghcr.io/<owner>/phlag --tag <version> [--latest]`.
 -   CI workflow `.github/workflows/ci.yml` builds and publishes images to GHCR using the built-in `GITHUB_TOKEN`, generates SBOM + provenance attestations, runs `docker buildx` checks, and stamps images with reproducible metadata (labels/annotations/tags driven by `SOURCE_DATE_EPOCH`).
+-   The published runtime image contains the `phlag` PHAR at `/app/phlag`, plus the production `public/` assets. `public/index.php` falls back to autoloading from the PHAR when the vendor tree is not mounted (for example, when consuming the published GHCR tag directly).
 -   Detailed sharing instructions live in [`doc/docker-image-sharing.md`](./doc/docker-image-sharing.md).
 -   DevSecOps validation steps (annotations, attestations, SBOM triage, and framework alignment) are captured in [`doc/devsecops.md`](./doc/devsecops.md).
 

--- a/doc/docker-image-sharing.md
+++ b/doc/docker-image-sharing.md
@@ -8,6 +8,8 @@ Some contributors prefer receiving pre-built Docker images instead of rebuilding
 - Exporting a locally built image so another teammate can load it.
 - Publishing an image to a container registry (for example GitHub Container Registry).
 
+The multi-stage Dockerfile compiles the Laravel Zero application into a PHAR (`/app/phlag`) and ships only that artifact plus the production `public/` assets in the final image. When you run the container without bind mounts, `public/index.php` automatically boots from the bundled PHAR so the HTTP health endpoint (and any future web entrypoints) stay operational.
+
 Both approaches produce an image compatible with the `app` service defined in `compose.yaml`. The stack now pulls `${PHLAG_APP_IMAGE:-ghcr.io/danhenke/phlag:latest}` automatically, so sharing an image primarily helps teammates who are offline or need to test an unpublished build. The CI workflow publishes multi-architecture images (`linux/amd64` and `linux/arm64`), letting Docker Compose choose the right variant for each host without extra configuration.
 
 ## Prerequisites

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,22 @@
 
 declare(strict_types=1);
 
-require_once __DIR__.'/../vendor/autoload.php';
+$autoloadPath = __DIR__.'/../vendor/autoload.php';
+
+if (file_exists($autoloadPath)) {
+    require_once $autoloadPath;
+} else {
+    $pharPath = getenv('PHLAG_PHAR') ?: __DIR__.'/../phlag';
+    $resolvedPhar = realpath($pharPath);
+
+    if ($resolvedPhar !== false) {
+        $pharAutoload = sprintf('phar://%s/vendor/autoload.php', $resolvedPhar);
+
+        if (file_exists($pharAutoload)) {
+            require_once $pharAutoload;
+        }
+    }
+}
 
 header('Content-Type: application/json');
 


### PR DESCRIPTION
## Summary
- ship phlag as a PHAR within the published container image
- tighten runtime layer to only include extensions + public assets
- document the new flow for consumers of ghcr.io/danhenke/phlag

## Issue
- Resolves #51

## Validation
- [x] `composer test`
- [ ] `composer lint`
- [ ] `composer stan`
- [ ] Other: 

<details>
<summary>Validation Evidence</summary>

```
$ composer test

   PASS  Tests\Feature\DatabaseCommandsTest
  ✓ it migrates the database schema                                      0.15s  
  ✓ it seeds demo records after migrating                                0.03s  
  ✓ it can seed repeatedly without creating duplicates                   0.02s  

   PASS  Tests\Unit\Models\ModelConfigurationTest
  ✓ it configures project model casting and key handling
  ✓ it configures environment model casting and key handling
  ✓ it configures flag model casting and key handling
  ✓ it configures evaluation model casting and key handling
  ✓ it configures audit event model casting and key handling

  Tests:    8 passed (54 assertions)
  Duration: 0.26s
```

</details>

## Deployment & Operational Notes
- [ ] Database migrations required
- [ ] Environment variables or secrets updated
- [ ] Operational runbook or alerting updates

## Additional Context
- None.
