### PR TITLE
Document error envelope in OpenAPI spec

### DIFF
--- a/api/swagger.php
+++ b/api/swagger.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenApi\Generator;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$paths = [
+    __DIR__.'/../app',
+    __DIR__.'/../routes',
+];
+
+try {
+    $openApi = Generator::scan($paths);
+} catch (\Throwable $exception) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "Failed to generate OpenAPI specification: %s\n",
+            $exception->getMessage()
+        )
+    );
+    exit(1);
+}
+
+echo $openApi->toJson(
+    JSON_PRETTY_PRINT
+    | JSON_UNESCAPED_SLASHES
+    | JSON_UNESCAPED_UNICODE
+).PHP_EOL;

--- a/app/OpenApi/OpenApiSpec.php
+++ b/app/OpenApi/OpenApiSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Info(
+    title: 'Phlag API',
+    version: '1.0.0',
+    description: 'API for managing feature flags, environments, and evaluations within Phlag.'
+)]
+#[OA\Server(
+    url: 'http://localhost',
+    description: 'Local development server'
+)]
+final class OpenApiSpec {}

--- a/app/OpenApi/Paths/HealthCheck.php
+++ b/app/OpenApi/Paths/HealthCheck.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi\Paths;
+
+use OpenApi\Attributes as OA;
+
+#[OA\PathItem(path: '/')]
+final class HealthCheck
+{
+    #[OA\Get(
+        path: '/',
+        operationId: 'getHealthCheck',
+        summary: 'Retrieve service health status.',
+        tags: ['System'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Service is available.',
+                content: new OA\JsonContent(
+                    type: 'object',
+                    required: ['service', 'status', 'timestamp'],
+                    properties: [
+                        new OA\Property(
+                            property: 'service',
+                            type: 'string',
+                            description: 'Service identifier.'
+                        ),
+                        new OA\Property(
+                            property: 'status',
+                            type: 'string',
+                            enum: ['ok'],
+                            description: 'Service availability status.'
+                        ),
+                        new OA\Property(
+                            property: 'timestamp',
+                            type: 'string',
+                            format: 'date-time',
+                            description: 'ISO-8601 timestamp when the health check was evaluated.'
+                        ),
+                    ],
+                    description: 'Health check payload.'
+                )
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    public function __invoke(): void
+    {
+        // Specification-only placeholder.
+    }
+}

--- a/app/OpenApi/Schemas/ErrorSchemas.php
+++ b/app/OpenApi/Schemas/ErrorSchemas.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ErrorViolation',
+    type: 'object',
+    required: ['field', 'message'],
+    properties: [
+        new OA\Property(
+            property: 'field',
+            type: 'string',
+            description: 'Field path that failed validation.'
+        ),
+        new OA\Property(
+            property: 'message',
+            type: 'string',
+            description: 'Human-readable description of the validation error.'
+        ),
+    ],
+    description: 'Details of a single validation violation.'
+)]
+#[OA\Schema(
+    schema: 'ErrorEnvelope',
+    type: 'object',
+    required: ['code', 'message', 'status'],
+    properties: [
+        new OA\Property(
+            property: 'code',
+            type: 'string',
+            description: 'Machine-readable error identifier.',
+            enum: [
+                'bad_request',
+                'conflict',
+                'forbidden',
+                'http_error',
+                'method_not_allowed',
+                'not_implemented',
+                'rate_limited',
+                'resource_not_found',
+                'server_error',
+                'unauthorized',
+                'validation_failed',
+            ]
+        ),
+        new OA\Property(
+            property: 'message',
+            type: 'string',
+            description: 'Concise, human-readable explanation of the error.'
+        ),
+        new OA\Property(
+            property: 'status',
+            type: 'integer',
+            format: 'int32',
+            description: 'HTTP status code associated with the error.'
+        ),
+        new OA\Property(
+            property: 'detail',
+            type: 'string',
+            nullable: true,
+            description: 'Optional detail for debugging when debug mode is enabled.'
+        ),
+        new OA\Property(
+            property: 'context',
+            type: 'object',
+            nullable: true,
+            description: 'Optional key-value pairs providing additional context for the error.'
+        ),
+        new OA\Property(
+            property: 'violations',
+            type: 'array',
+            nullable: true,
+            items: new OA\Items(ref: '#/components/schemas/ErrorViolation'),
+            description: 'List of validation violations when the error represents validation failures.'
+        ),
+    ],
+    description: 'Standardized error payload returned by the Phlag API.'
+)]
+#[OA\Schema(
+    schema: 'ErrorResponse',
+    type: 'object',
+    required: ['error'],
+    properties: [
+        new OA\Property(
+            property: 'error',
+            ref: '#/components/schemas/ErrorEnvelope',
+            description: 'Standardized error envelope.'
+        ),
+    ],
+    description: 'Envelope for all error responses returned by the Phlag API.'
+)]
+final class ErrorSchemas {}

--- a/app/Support/View/NullViewFactory.php
+++ b/app/Support/View/NullViewFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phlag\Support\View;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\View\Factory as FactoryContract;
 use LogicException;
 
@@ -21,44 +22,75 @@ final class NullViewFactory implements FactoryContract
         return false;
     }
 
+    /**
+     * @param  Arrayable<string, mixed>|array<string, mixed>  $data
+     * @param  array<string, mixed>  $mergeData
+     */
     public function file($path, $data = [], $mergeData = [])
     {
         throw new LogicException('View rendering is not supported in this application.');
     }
 
+    /**
+     * @param  Arrayable<string, mixed>|array<string, mixed>  $data
+     * @param  array<string, mixed>  $mergeData
+     */
     public function make($view, $data = [], $mergeData = [])
     {
         throw new LogicException('View rendering is not supported in this application.');
     }
 
+    /**
+     * @param  array<string, mixed>|string  $key
+     * @param  mixed  $value
+     * @return array<string, mixed>|mixed
+     */
     public function share($key, $value = null)
     {
         if (is_array($key)) {
             foreach ($key as $nestedKey => $nestedValue) {
-                $this->shared[$nestedKey] = $nestedValue;
+                $this->shared[(string) $nestedKey] = $nestedValue;
             }
 
             return $this->shared;
         }
 
-        return $this->shared[$key] = $value;
+        return $this->shared[(string) $key] = $value;
     }
 
+    /**
+     * @param  array<int, string>|string  $views
+     * @param  callable|string  $callback
+     * @return array<int, mixed>
+     */
     public function composer($views, $callback)
     {
         return [];
     }
 
+    /**
+     * @param  array<int, string>|string  $views
+     * @param  callable|string  $callback
+     * @return array<int, mixed>
+     */
     public function creator($views, $callback)
     {
         return [];
     }
 
+    /**
+     * @param  array<int, string>|string  $hints
+     * @return $this
+     */
     public function addNamespace($namespace, $hints)
     {
         return $this;
     }
 
+    /**
+     * @param  array<int, string>|string  $hints
+     * @return $this
+     */
     public function replaceNamespace($namespace, $hints)
     {
         return $this;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,9 +7,9 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Http\Request;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Validation\ValidationException;
 use LaravelZero\Framework\Application;
@@ -145,9 +145,9 @@ $app = Application::configure(basePath: dirname(__DIR__))
     })
     ->create();
 
-$app->singleton(Filesystem::class, fn () => new Filesystem());
+$app->singleton(Filesystem::class, fn () => new Filesystem);
 $app->alias(Filesystem::class, 'files');
-$app->singleton(ViewFactoryContract::class, fn () => new NullViewFactory());
+$app->singleton(ViewFactoryContract::class, fn () => new NullViewFactory);
 $app->alias(ViewFactoryContract::class, 'view');
 
 $app->register(RoutingServiceProvider::class);

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,11 @@
         "php": "^8.4",
         "illuminate/database": "^12.32.5",
         "illuminate/http": "^12.32",
-        "illuminate/routing": "^12.32",
         "illuminate/pagination": "^12.32",
+        "illuminate/routing": "^12.32",
         "illuminate/validation": "^12.32",
-        "laravel-zero/framework": "^12.0.2"
+        "laravel-zero/framework": "^12.0.2",
+        "zircote/swagger-php": "^4.10"
     },
     "require-dev": {
         "laravel/pint": "^1.25.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37b22a86c09df47023bf718e57046e96",
+    "content-hash": "59274ad499f5c22d26ac6e0c7d94937a",
     "packages": [
         {
             "name": "brick/math",
@@ -6317,6 +6317,82 @@
             "time": "2025-09-11T10:12:26+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
+        },
+        {
             "name": "vlucas/phpdotenv",
             "version": "v5.6.2",
             "source": {
@@ -6531,6 +6607,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || 3.62.0",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.11.1"
+            },
+            "time": "2024-10-15T19:20:02+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,166 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Phlag API",
+        "description": "API for managing feature flags, environments, and evaluations within Phlag.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost",
+            "description": "Local development server"
+        }
+    ],
+    "paths": {
+        "/": {
+            "get": {
+                "tags": [
+                    "System"
+                ],
+                "summary": "Retrieve service health status.",
+                "operationId": "getHealthCheck",
+                "responses": {
+                    "200": {
+                        "description": "Service is available.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Health check payload.",
+                                    "required": [
+                                        "service",
+                                        "status",
+                                        "timestamp"
+                                    ],
+                                    "properties": {
+                                        "service": {
+                                            "description": "Service identifier.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Service availability status.",
+                                            "type": "string",
+                                            "enum": [
+                                                "ok"
+                                            ]
+                                        },
+                                        "timestamp": {
+                                            "description": "ISO-8601 timestamp when the health check was evaluated.",
+                                            "type": "string",
+                                            "format": "date-time"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ErrorViolation": {
+                "description": "Details of a single validation violation.",
+                "required": [
+                    "field",
+                    "message"
+                ],
+                "properties": {
+                    "field": {
+                        "description": "Field path that failed validation.",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Human-readable description of the validation error.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorEnvelope": {
+                "description": "Standardized error payload returned by the Phlag API.",
+                "required": [
+                    "code",
+                    "message",
+                    "status"
+                ],
+                "properties": {
+                    "code": {
+                        "description": "Machine-readable error identifier.",
+                        "type": "string",
+                        "enum": [
+                            "bad_request",
+                            "conflict",
+                            "forbidden",
+                            "http_error",
+                            "method_not_allowed",
+                            "not_implemented",
+                            "rate_limited",
+                            "resource_not_found",
+                            "server_error",
+                            "unauthorized",
+                            "validation_failed"
+                        ]
+                    },
+                    "message": {
+                        "description": "Concise, human-readable explanation of the error.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "HTTP status code associated with the error.",
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "detail": {
+                        "description": "Optional detail for debugging when debug mode is enabled.",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "context": {
+                        "description": "Optional key-value pairs providing additional context for the error.",
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "violations": {
+                        "description": "List of validation violations when the error represents validation failures.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorViolation"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorResponse": {
+                "description": "Envelope for all error responses returned by the Phlag API.",
+                "required": [
+                    "error"
+                ],
+                "properties": {
+                    "error": {
+                        "$ref": "#/components/schemas/ErrorEnvelope"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "System",
+            "description": "System"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add swagger-php and stub OpenAPI spec scaffolding for the service
- document the shared error envelope schema and health check response
- generate docs/openapi.json via a repeatable `api/swagger.php` helper

## Testing
- composer test
- composer lint
- composer stan

Closes #58.