### PR TITLE
Summarize exceptions in container logs

### DIFF
--- a/app/Logging/ExceptionSummaryProcessor.php
+++ b/app/Logging/ExceptionSummaryProcessor.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Logging;
+
+use Throwable;
+
+final class ExceptionSummaryProcessor
+{
+    /**
+     * Invoke the processor.
+     *
+     * @param  array<string, mixed>  $record
+     * @return array<string, mixed>
+     */
+    public function __invoke(array $record): array
+    {
+        $context = $record['context'] ?? null;
+
+        if (! is_array($context)) {
+            return $record;
+        }
+
+        $exception = $context['exception'] ?? null;
+
+        if (! $exception instanceof Throwable) {
+            return $record;
+        }
+
+        $message = $this->stringify($record['message'] ?? '');
+        $exceptionMessage = $exception->getMessage();
+
+        $summary = sprintf(
+            '%s:%d %s: %s',
+            $this->relativePath($exception->getFile()),
+            $exception->getLine(),
+            class_basename($exception::class),
+            $this->normalizeMessage($exception->getMessage())
+        );
+
+        if ($message !== '' && $message !== $exceptionMessage) {
+            $summary .= sprintf(' | %s', $this->collapseWhitespace($message));
+        }
+
+        $record['message'] = $summary;
+
+        return $record;
+    }
+
+    private function normalizeMessage(?string $message): string
+    {
+        $trimmed = trim((string) $message);
+
+        if ($trimmed === '') {
+            return '(no message)';
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $trimmed);
+
+        return $normalized === null ? $trimmed : $normalized;
+    }
+
+    private function relativePath(string $path): string
+    {
+        $basePath = base_path();
+
+        if ($path !== '' && str_starts_with($path, $basePath)) {
+            return ltrim(str_replace($basePath, '', $path), DIRECTORY_SEPARATOR);
+        }
+
+        return $path;
+    }
+
+    private function collapseWhitespace(string $value): string
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($value));
+
+        return $normalized === null ? trim($value) : $normalized;
+    }
+
+    private function stringify(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string) $value;
+        }
+
+        return '';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "illuminate/http": "^12.32",
         "illuminate/pagination": "^12.32",
         "illuminate/routing": "^12.32",
+        "illuminate/log": "^12.32",
         "illuminate/validation": "^12.32",
         "laravel-zero/framework": "^12.0.2",
         "zircote/swagger-php": "^4.10"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59274ad499f5c22d26ac6e0c7d94937a",
+    "content-hash": "566b5b9675cb5ff908df28c89e18d195",
     "packages": [
         {
             "name": "brick/math",
@@ -1748,6 +1748,59 @@
             "time": "2025-10-06T22:01:13+00:00"
         },
         {
+            "name": "illuminate/log",
+            "version": "v12.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/log.git",
+                "reference": "535f80fd257318656d1d29c4e8f679d0f4b195b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/log/zipball/535f80fd257318656d1d29c4e8f679d0f4b195b2",
+                "reference": "535f80fd257318656d1d29c4e8f679d0f4b195b2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^12.0",
+                "illuminate/support": "^12.0",
+                "monolog/monolog": "^3.0",
+                "php": "^8.2",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Log package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-09-21T15:11:44+00:00"
+        },
+        {
             "name": "illuminate/macroable",
             "version": "v12.33.0",
             "source": {
@@ -2974,6 +3027,109 @@
                 }
             ],
             "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,136 @@
+<?php
+
+use Monolog\Handler\NullHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
+use Phlag\Logging\ExceptionSummaryProcessor;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Log Channel
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the default log channel that is utilized to write
+    | messages to your logs. The value provided here should match one of
+    | the channels present in the list of "channels" configured below.
+    |
+    */
+
+    'default' => env('LOG_CHANNEL', 'stack'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Deprecations Log Channel
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the log channel that should be used to log warnings
+    | regarding deprecated PHP and library features. This allows you to get
+    | your application ready for upcoming major versions of dependencies.
+    |
+    */
+
+    'deprecations' => [
+        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+        'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Log Channels
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the log channels for your application. Laravel
+    | utilizes the Monolog PHP logging library, which includes a variety
+    | of powerful log handlers and formatters that you're free to use.
+    |
+    | Available drivers: "single", "daily", "slack", "syslog",
+    |                    "errorlog", "monolog", "custom", "stack"
+    |
+    */
+
+    'channels' => [
+
+        'stack' => [
+            'driver' => 'stack',
+            'channels' => explode(',', (string) env('LOG_STACK', 'stderr')),
+            'ignore_exceptions' => false,
+        ],
+
+        'single' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
+        'daily' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'slack' => [
+            'driver' => 'slack',
+            'url' => env('LOG_SLACK_WEBHOOK_URL'),
+            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+            'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
+            'level' => env('LOG_LEVEL', 'critical'),
+            'replace_placeholders' => true,
+        ],
+
+        'papertrail' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
+            'handler_with' => [
+                'host' => env('PAPERTRAIL_URL'),
+                'port' => env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
+            ],
+            'processors' => [PsrLogMessageProcessor::class],
+        ],
+
+        'stderr' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => 'php://stderr',
+            ],
+            'formatter' => env('LOG_STDERR_FORMATTER'),
+            'processors' => [
+                ExceptionSummaryProcessor::class,
+                PsrLogMessageProcessor::class,
+            ],
+        ],
+
+        'syslog' => [
+            'driver' => 'syslog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
+            'replace_placeholders' => true,
+        ],
+
+        'errorlog' => [
+            'driver' => 'errorlog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ],
+
+        'emergency' => [
+            'path' => storage_path('logs/laravel.log'),
+        ],
+
+    ],
+
+];

--- a/tests/Unit/Logging/ExceptionSummaryProcessorTest.php
+++ b/tests/Unit/Logging/ExceptionSummaryProcessorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Phlag\Logging\ExceptionSummaryProcessor;
+
+it('builds a summary from an exception', function (): void {
+    $processor = new ExceptionSummaryProcessor;
+
+    $exception = new RuntimeException('Boom');
+
+    $record = $processor([
+        'message' => 'Boom',
+        'context' => ['exception' => $exception],
+    ]);
+
+    expect($record['message'])
+        ->toContain('tests/Unit/Logging/ExceptionSummaryProcessorTest.php')
+        ->toContain('RuntimeException: Boom');
+});
+
+it('appends original message when different from exception message', function (): void {
+    $processor = new ExceptionSummaryProcessor;
+
+    $exception = new RuntimeException('Explosion');
+
+    $record = $processor([
+        'message' => 'Processing payment failed',
+        'context' => ['exception' => $exception],
+    ]);
+
+    expect($record['message'])
+        ->toContain('tests/Unit/Logging/ExceptionSummaryProcessorTest.php')
+        ->toContain('RuntimeException: Explosion')
+        ->toContain('Processing payment failed');
+});


### PR DESCRIPTION
## Summary
- add a custom Monolog processor that emits single-line exception summaries with file, line, class, and message
- configure the stderr channel to run through the new processor and pull in illuminate/log so it is available in the app container
- cover the processor with unit tests around summary formatting and message merging

## Testing
- composer lint
- composer test
- composer stan

Closes #63.