### PR TITLE
Stop building app image inside Docker Compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@
 ## Build, Test, and Development Commands
 
 -   `composer install` — install PHP dependencies with locked versions.
--   `docker compose up -d` — start the application, PostgreSQL, and Redis services (Builds the app image locally unless you set `PHLAG_APP_IMAGE` to a prebuilt tag).
+-   `./scripts/docker-build-app` — build (or rebuild) the application image tagged as `${PHLAG_APP_IMAGE:-phlag-app:latest}` before running Compose locally.
+-   `docker compose up -d` — start the application, PostgreSQL, and Redis services using the prebuilt image (override `PHLAG_APP_IMAGE` to point at a registry tag).
 -   `docker compose exec app php phlag app:migrate` — run database migrations through the Laravel Zero binary.
 -   `docker compose exec app php phlag cache:warm {project} {env}` — refresh Redis caches when flag logic changes.
 -   `composer test` — execute the Pest test suites with PHPUnit under the hood.

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,9 +2,6 @@ name: "phlag"
 
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
     image: ${PHLAG_APP_IMAGE:-phlag-app:latest}
     command:
       - /usr/local/bin/php

--- a/doc/docker-troubleshooting.md
+++ b/doc/docker-troubleshooting.md
@@ -54,7 +54,7 @@ Both reported versions should meet or exceed the minimums above. If they do not,
     }
     ```
 
-3. Retry `docker compose build app`.
+3. Re-run `./scripts/docker-build-app`.
 
 ### `docker compose up` fails because port 80 is already in use
 
@@ -116,8 +116,6 @@ set -a; source .env.local; set +a
 2. Rebuild the image for your host platform:
 
     ```bash
-    docker compose build app
-    # or
     ./scripts/docker-build-app --platform "$(docker info --format '{{.Architecture}}')"
     ```
 


### PR DESCRIPTION
## Summary
- drop the `build:` directive from compose so the app service relies on `${PHLAG_APP_IMAGE:-phlag-app:latest}`
- document the new workflow: run `./scripts/docker-build-app` (or supply a prebuilt tag) before `docker compose up`
- update troubleshooting guidance to point to the helper build script instead of `docker compose build`

## Testing
- docs/config updates only