### PR TITLE
Make app container self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,13 @@ RUN useradd --system --create-home phlag \
     && chown -R phlag:phlag /app
 ENV PHLAG_PHAR=/app/phlag
 
-COPY public ./public
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/bootstrap ./bootstrap
+COPY --from=builder /app/config ./config
+COPY --from=builder /app/routes ./routes
+COPY --from=builder /app/app ./app
+COPY --from=builder /app/vendor ./vendor
+COPY --from=builder /app/database ./database
 COPY --from=builder /app/builds/phlag ./phlag
 
 RUN chmod +x /app/phlag \
@@ -48,8 +54,10 @@ RUN chmod +x /app/phlag \
     && chown -h phlag:phlag /usr/local/bin/phlag \
     && setcap 'cap_net_bind_service=+ep' /usr/local/bin/php
 
+WORKDIR /app
+
 USER phlag
 
 EXPOSE 80
 
-CMD ["/usr/local/bin/php", "-S", "0.0.0.0:80", "-t", "public", "public/index.php"]
+CMD ["/usr/local/bin/php", "-S", "0.0.0.0:80", "-t", "/app/public", "/app/public/index.php"]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ This launches three services within an isolated Docker network:
 
 Only the application’s port 80 is published to your LAN (`http://localhost/` by default). Re-run `./scripts/docker-build-app` whenever you change PHP dependencies or base layers so the `${PHLAG_APP_IMAGE:-phlag-app:latest}` tag stays in sync with your working tree.
 
+Need to live-edit code inside the container? Add a local override (for example `compose.override.yaml`) that bind-mounts your working tree into `/app`. Remember this bypasses the packaged PHAR and assets that ship with the image, so disable it when you want to validate what will run in other environments.
+
 Logs remain on stdout; tail them with `docker compose logs -f` when debugging. The Compose file configures the `json-file` driver with `max-size=10m` and `max-file=5`, so each container keeps a rotating local buffer without requiring extra volumes.
 
 #### Quick smoke tests without Docker

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,13 +3,7 @@ name: "phlag"
 services:
   app:
     image: ${PHLAG_APP_IMAGE:-phlag-app:latest}
-    command:
-      - /usr/local/bin/php
-      - -S
-      - 0.0.0.0:80
-      - -t
-      - public
-      - public/index.php
+    platform: linux/amd64
     depends_on:
       postgres:
         condition: service_healthy
@@ -21,8 +15,6 @@ services:
       APP_ENV: ${APP_ENV:-local}
     ports:
       - "80:80"
-    volumes:
-      - ./:/app
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary
- drop the default bind mount from the app service so the container runs the packaged PHAR/assets
- copy the framework/runtime directories from the builder stage into the runtime image
- rely on the image CMD for the PHP server and document optional local overrides

## Testing
- docs/config updates only