### PR TITLE
Expand OpenAPI coverage and generation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ PR descriptions should also mention any migrations, environment variables, or op
 Regenerate docs once you have sourced environment variables:
 
 ```bash
-php api/swagger.php > docs/openapi.json
+composer openapi:generate
 ```
 
 ---

--- a/api/swagger.php
+++ b/api/swagger.php
@@ -11,6 +11,8 @@ $paths = [
     __DIR__.'/../routes',
 ];
 
+$outputPath = $argv[1] ?? null;
+
 try {
     $openApi = Generator::scan($paths);
 } catch (\Throwable $exception) {
@@ -24,8 +26,26 @@ try {
     exit(1);
 }
 
-echo $openApi->toJson(
+$json = $openApi->toJson(
     JSON_PRETTY_PRINT
     | JSON_UNESCAPED_SLASHES
     | JSON_UNESCAPED_UNICODE
 ).PHP_EOL;
+
+if ($outputPath !== null) {
+    if (@file_put_contents($outputPath, $json) === false) {
+        fwrite(
+            STDERR,
+            sprintf(
+                "Failed to write OpenAPI specification to %s\n",
+                $outputPath
+            )
+        );
+
+        exit(1);
+    }
+
+    exit(0);
+}
+
+echo $json;

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
+use OpenApi\Attributes as OA;
 use Phlag\Http\Requests\StoreProjectRequest;
 use Phlag\Http\Requests\UpdateProjectRequest;
 use Phlag\Http\Resources\ProjectResource;
@@ -21,6 +22,48 @@ class ProjectController extends Controller
     /**
      * List projects with pagination support.
      */
+    #[OA\Get(
+        path: '/v1/projects',
+        operationId: 'listProjects',
+        summary: 'List projects',
+        tags: ['Projects'],
+        parameters: [
+            new OA\QueryParameter(
+                name: 'page',
+                description: 'Page number to retrieve.',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1)
+            ),
+            new OA\QueryParameter(
+                name: 'per_page',
+                description: 'Number of results per page (1-100).',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100)
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Paginated list of projects.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ProjectCollection')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 429,
+                description: 'Too many requests.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function index(Request $request): AnonymousResourceCollection
     {
         $perPage = (int) $request->integer('per_page', 15);
@@ -39,6 +82,45 @@ class ProjectController extends Controller
     /**
      * Store a newly created project.
      */
+    #[OA\Post(
+        path: '/v1/projects',
+        operationId: 'createProject',
+        summary: 'Create a project',
+        tags: ['Projects'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/ProjectCreateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Project created.',
+                headers: [
+                    new OA\Header(
+                        header: 'Location',
+                        description: 'URI of the created project.',
+                        schema: new OA\Schema(type: 'string', format: 'uri')
+                    ),
+                ],
+                content: new OA\JsonContent(ref: '#/components/schemas/ProjectResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function store(StoreProjectRequest $request): JsonResponse
     {
         /** @var array<string, mixed> $data */
@@ -64,6 +146,42 @@ class ProjectController extends Controller
     /**
      * Display the specified project.
      */
+    #[OA\Get(
+        path: '/v1/projects/{project}',
+        operationId: 'getProject',
+        summary: 'Fetch a project',
+        tags: ['Projects'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Project details.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ProjectResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function show(Project $project): ProjectResource
     {
         $project->load('environments');
@@ -74,6 +192,96 @@ class ProjectController extends Controller
     /**
      * Update the specified project.
      */
+    #[OA\Patch(
+        path: '/v1/projects/{project}',
+        operationId: 'updateProject',
+        summary: 'Update a project',
+        tags: ['Projects'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/ProjectUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Project updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ProjectResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    #[OA\Put(
+        path: '/v1/projects/{project}',
+        operationId: 'replaceProject',
+        summary: 'Replace a project',
+        tags: ['Projects'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/ProjectUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Project updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ProjectResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function update(UpdateProjectRequest $request, Project $project): ProjectResource
     {
         /** @var array<string, mixed> $data */
@@ -90,6 +298,38 @@ class ProjectController extends Controller
     /**
      * Remove the specified project.
      */
+    #[OA\Delete(
+        path: '/v1/projects/{project}',
+        operationId: 'deleteProject',
+        summary: 'Delete a project',
+        tags: ['Projects'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Project deleted.'),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function destroy(Project $project): Response
     {
         $project->delete();

--- a/app/Http/Controllers/ProjectEnvironmentController.php
+++ b/app/Http/Controllers/ProjectEnvironmentController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
+use OpenApi\Attributes as OA;
 use Phlag\Http\Requests\StoreEnvironmentRequest;
 use Phlag\Http\Requests\UpdateEnvironmentRequest;
 use Phlag\Http\Resources\EnvironmentResource;
@@ -22,6 +23,59 @@ class ProjectEnvironmentController extends Controller
     /**
      * List environments for the given project.
      */
+    #[OA\Get(
+        path: '/v1/projects/{project}/environments',
+        operationId: 'listProjectEnvironments',
+        summary: 'List environments for a project',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'page',
+                description: 'Page number to retrieve.',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1)
+            ),
+            new OA\QueryParameter(
+                name: 'per_page',
+                description: 'Number of results per page (1-100).',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100)
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Paginated list of environments.',
+                content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentCollection')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 429,
+                description: 'Too many requests.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function index(Request $request, Project $project): AnonymousResourceCollection
     {
         $perPage = (int) $request->integer('per_page', 15);
@@ -40,6 +94,58 @@ class ProjectEnvironmentController extends Controller
     /**
      * Store a newly created environment.
      */
+    #[OA\Post(
+        path: '/v1/projects/{project}/environments',
+        operationId: 'createProjectEnvironment',
+        summary: 'Create an environment for a project',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentCreateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Environment created.',
+                headers: [
+                    new OA\Header(
+                        header: 'Location',
+                        description: 'URI of the created environment.',
+                        schema: new OA\Schema(type: 'string', format: 'uri')
+                    ),
+                ],
+                content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function store(StoreEnvironmentRequest $request, Project $project): JsonResponse
     {
         /** @var array<string, mixed> $data */
@@ -71,6 +177,48 @@ class ProjectEnvironmentController extends Controller
     /**
      * Display the specified environment.
      */
+    #[OA\Get(
+        path: '/v1/projects/{project}/environments/{environment}',
+        operationId: 'getProjectEnvironment',
+        summary: 'Fetch an environment',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'environment',
+                description: 'Environment key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Environment details.',
+                content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Environment or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function show(Project $project, Environment $environment): EnvironmentResource
     {
         return new EnvironmentResource($environment);
@@ -79,6 +227,108 @@ class ProjectEnvironmentController extends Controller
     /**
      * Update the specified environment.
      */
+    #[OA\Patch(
+        path: '/v1/projects/{project}/environments/{environment}',
+        operationId: 'updateProjectEnvironment',
+        summary: 'Update an environment',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'environment',
+                description: 'Environment key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Environment updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Environment or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    #[OA\Put(
+        path: '/v1/projects/{project}/environments/{environment}',
+        operationId: 'replaceProjectEnvironment',
+        summary: 'Replace an environment',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'environment',
+                description: 'Environment key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Environment updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/EnvironmentResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Environment or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function update(
         UpdateEnvironmentRequest $request,
         Project $project,
@@ -104,6 +354,44 @@ class ProjectEnvironmentController extends Controller
     /**
      * Remove the specified environment.
      */
+    #[OA\Delete(
+        path: '/v1/projects/{project}/environments/{environment}',
+        operationId: 'deleteProjectEnvironment',
+        summary: 'Delete an environment',
+        tags: ['Environments'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'environment',
+                description: 'Environment key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Environment deleted.'),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Environment or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function destroy(Project $project, Environment $environment): Response
     {
         $environment->delete();

--- a/app/Http/Controllers/ProjectFlagController.php
+++ b/app/Http/Controllers/ProjectFlagController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
+use OpenApi\Attributes as OA;
 use Phlag\Http\Requests\StoreFlagRequest;
 use Phlag\Http\Requests\UpdateFlagRequest;
 use Phlag\Http\Resources\FlagResource;
@@ -22,6 +23,59 @@ class ProjectFlagController extends Controller
     /**
      * List flags for the given project.
      */
+    #[OA\Get(
+        path: '/v1/projects/{project}/flags',
+        operationId: 'listProjectFlags',
+        summary: 'List flags for a project',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'page',
+                description: 'Page number to retrieve.',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1)
+            ),
+            new OA\QueryParameter(
+                name: 'per_page',
+                description: 'Number of results per page (1-100).',
+                required: false,
+                schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100)
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Paginated list of flags.',
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagCollection')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 429,
+                description: 'Too many requests.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function index(Request $request, Project $project): AnonymousResourceCollection
     {
         $perPage = (int) $request->integer('per_page', 15);
@@ -40,6 +94,58 @@ class ProjectFlagController extends Controller
     /**
      * Store a newly created flag.
      */
+    #[OA\Post(
+        path: '/v1/projects/{project}/flags',
+        operationId: 'createProjectFlag',
+        summary: 'Create a flag for a project',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/FlagCreateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Flag created.',
+                headers: [
+                    new OA\Header(
+                        header: 'Location',
+                        description: 'URI of the created flag.',
+                        schema: new OA\Schema(type: 'string', format: 'uri')
+                    ),
+                ],
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function store(StoreFlagRequest $request, Project $project): JsonResponse
     {
         /** @var array<string, mixed> $data */
@@ -70,6 +176,48 @@ class ProjectFlagController extends Controller
     /**
      * Display the specified flag.
      */
+    #[OA\Get(
+        path: '/v1/projects/{project}/flags/{flag}',
+        operationId: 'getProjectFlag',
+        summary: 'Fetch a flag',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'flag',
+                description: 'Flag key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Flag details.',
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Flag or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function show(Project $project, Flag $flag): FlagResource
     {
         return new FlagResource($flag);
@@ -78,6 +226,108 @@ class ProjectFlagController extends Controller
     /**
      * Update the specified flag.
      */
+    #[OA\Patch(
+        path: '/v1/projects/{project}/flags/{flag}',
+        operationId: 'updateProjectFlag',
+        summary: 'Update a flag',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'flag',
+                description: 'Flag key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/FlagUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Flag updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Flag or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    #[OA\Put(
+        path: '/v1/projects/{project}/flags/{flag}',
+        operationId: 'replaceProjectFlag',
+        summary: 'Replace a flag',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'flag',
+                description: 'Flag key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/FlagUpdateRequest')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Flag updated.',
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagResponse')
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Flag or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function update(UpdateFlagRequest $request, Project $project, Flag $flag): FlagResource
     {
         /** @var array<string, mixed> $data */
@@ -98,6 +348,44 @@ class ProjectFlagController extends Controller
     /**
      * Remove the specified flag.
      */
+    #[OA\Delete(
+        path: '/v1/projects/{project}/flags/{flag}',
+        operationId: 'deleteProjectFlag',
+        summary: 'Delete a flag',
+        tags: ['Flags'],
+        parameters: [
+            new OA\PathParameter(
+                name: 'project',
+                description: 'Project key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\PathParameter(
+                name: 'flag',
+                description: 'Flag key.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Flag deleted.'),
+            new OA\Response(
+                response: 401,
+                description: 'Authentication is required.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Flag or project not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
     public function destroy(Project $project, Flag $flag): Response
     {
         $flag->delete();

--- a/app/OpenApi/Paths/StubPaths.php
+++ b/app/OpenApi/Paths/StubPaths.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi\Paths;
+
+use OpenApi\Attributes as OA;
+
+final class StubPaths
+{
+    #[OA\Post(
+        path: '/v1/auth/token',
+        operationId: 'issueAuthToken',
+        summary: 'Issue an authentication token (stub)',
+        tags: ['Authentication'],
+        responses: [
+            new OA\Response(
+                response: 501,
+                description: 'Endpoint not implemented yet.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    public function token(): void {}
+
+    #[OA\Get(
+        path: '/v1/evaluate',
+        operationId: 'evaluateFlag',
+        summary: 'Evaluate a feature flag (stub)',
+        tags: ['Flags'],
+        responses: [
+            new OA\Response(
+                response: 501,
+                description: 'Endpoint not implemented yet.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    public function evaluate(): void {}
+}

--- a/app/OpenApi/Schemas/DomainSchemas.php
+++ b/app/OpenApi/Schemas/DomainSchemas.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'Project',
+    required: ['id', 'key', 'name', 'created_at', 'updated_at', 'environments'],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'c0a8012a-7bb2-45cb-9e7a-17a4cda9e90a'),
+        new OA\Property(property: 'key', type: 'string', example: 'checkout-service'),
+        new OA\Property(property: 'name', type: 'string', example: 'Checkout Service'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+        new OA\Property(
+            property: 'environments',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/Environment')
+        ),
+    ],
+    description: 'Project representation returned by the API.'
+)]
+#[OA\Schema(
+    schema: 'ProjectResponse',
+    required: ['data'],
+    properties: [
+        new OA\Property(property: 'data', ref: '#/components/schemas/Project'),
+    ],
+    description: 'Single project response envelope.'
+)]
+#[OA\Schema(
+    schema: 'PaginationLinks',
+    type: 'object',
+    additionalProperties: new OA\AdditionalProperties(type: 'string', nullable: true),
+    description: 'Pagination links keyed by relation name.'
+)]
+#[OA\Schema(
+    schema: 'PaginationMeta',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'current_page', type: 'integer', minimum: 1),
+        new OA\Property(property: 'per_page', type: 'integer', minimum: 1),
+        new OA\Property(property: 'total', type: 'integer', minimum: 0),
+        new OA\Property(property: 'last_page', type: 'integer', minimum: 1, nullable: true),
+    ],
+    additionalProperties: new OA\AdditionalProperties,
+    description: 'Pagination metadata returned alongside resource collections.'
+)]
+#[OA\Schema(
+    schema: 'ProjectCollection',
+    required: ['data', 'links', 'meta'],
+    properties: [
+        new OA\Property(
+            property: 'data',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/Project')
+        ),
+        new OA\Property(property: 'links', ref: '#/components/schemas/PaginationLinks'),
+        new OA\Property(property: 'meta', ref: '#/components/schemas/PaginationMeta'),
+    ],
+    description: 'Paginated project collection response.'
+)]
+#[OA\Schema(
+    schema: 'Environment',
+    required: ['id', 'key', 'name', 'is_default', 'created_at', 'updated_at'],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'key', type: 'string'),
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_default', type: 'boolean'),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ],
+    description: 'Environment representation.'
+)]
+#[OA\Schema(
+    schema: 'EnvironmentResponse',
+    required: ['data'],
+    properties: [
+        new OA\Property(property: 'data', ref: '#/components/schemas/Environment'),
+    ],
+    description: 'Single environment response envelope.'
+)]
+#[OA\Schema(
+    schema: 'EnvironmentCollection',
+    required: ['data', 'links', 'meta'],
+    properties: [
+        new OA\Property(
+            property: 'data',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/Environment')
+        ),
+        new OA\Property(property: 'links', ref: '#/components/schemas/PaginationLinks'),
+        new OA\Property(property: 'meta', ref: '#/components/schemas/PaginationMeta'),
+    ],
+    description: 'Paginated environment collection response.'
+)]
+#[OA\Schema(
+    schema: 'FlagVariant',
+    required: ['key'],
+    properties: [
+        new OA\Property(property: 'key', type: 'string', example: 'variant-a'),
+        new OA\Property(property: 'weight', type: 'integer', minimum: 0, maximum: 100, nullable: true),
+        new OA\Property(
+            property: 'payload',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties
+        ),
+    ],
+    description: 'Flag variant configuration.'
+)]
+#[OA\Schema(
+    schema: 'FlagRule',
+    required: ['match', 'variant'],
+    properties: [
+        new OA\Property(
+            property: 'match',
+            type: 'object',
+            additionalProperties: new OA\AdditionalProperties(
+                type: 'array',
+                items: new OA\Items(type: 'string')
+            )
+        ),
+        new OA\Property(property: 'variant', type: 'string'),
+        new OA\Property(property: 'rollout', type: 'integer', nullable: true, minimum: 0, maximum: 100),
+    ],
+    description: 'Flag evaluation rule definition.'
+)]
+#[OA\Schema(
+    schema: 'Flag',
+    required: ['id', 'project_id', 'key', 'name', 'is_enabled', 'variants', 'created_at', 'updated_at'],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'project_id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'key', type: 'string'),
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_enabled', type: 'boolean'),
+        new OA\Property(
+            property: 'variants',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/FlagVariant')
+        ),
+        new OA\Property(
+            property: 'rules',
+            type: 'array',
+            nullable: true,
+            items: new OA\Items(ref: '#/components/schemas/FlagRule')
+        ),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ],
+    description: 'Flag representation.'
+)]
+#[OA\Schema(
+    schema: 'FlagResponse',
+    required: ['data'],
+    properties: [
+        new OA\Property(property: 'data', ref: '#/components/schemas/Flag'),
+    ],
+    description: 'Single flag response envelope.'
+)]
+#[OA\Schema(
+    schema: 'FlagCollection',
+    required: ['data', 'links', 'meta'],
+    properties: [
+        new OA\Property(
+            property: 'data',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/Flag')
+        ),
+        new OA\Property(property: 'links', ref: '#/components/schemas/PaginationLinks'),
+        new OA\Property(property: 'meta', ref: '#/components/schemas/PaginationMeta'),
+    ],
+    description: 'Paginated flag collection response.'
+)]
+#[OA\Schema(
+    schema: 'ProjectCreateRequest',
+    required: ['key', 'name'],
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+    ],
+    description: 'Payload for creating a project.'
+)]
+#[OA\Schema(
+    schema: 'ProjectUpdateRequest',
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+    ],
+    description: 'Payload for updating a project.'
+)]
+#[OA\Schema(
+    schema: 'EnvironmentCreateRequest',
+    required: ['key', 'name'],
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_default', type: 'boolean', nullable: true),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+    ],
+    description: 'Payload for creating an environment.'
+)]
+#[OA\Schema(
+    schema: 'EnvironmentUpdateRequest',
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_default', type: 'boolean', nullable: true),
+        new OA\Property(
+            property: 'metadata',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties(type: 'string')
+        ),
+    ],
+    description: 'Payload for updating an environment.'
+)]
+#[OA\Schema(
+    schema: 'FlagCreateRequest',
+    required: ['key', 'name', 'variants'],
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_enabled', type: 'boolean', nullable: true),
+        new OA\Property(
+            property: 'variants',
+            type: 'array',
+            minItems: 1,
+            items: new OA\Items(ref: '#/components/schemas/FlagVariant')
+        ),
+        new OA\Property(
+            property: 'rules',
+            type: 'array',
+            nullable: true,
+            items: new OA\Items(ref: '#/components/schemas/FlagRule')
+        ),
+    ],
+    description: 'Payload for creating a flag.'
+)]
+#[OA\Schema(
+    schema: 'FlagUpdateRequest',
+    properties: [
+        new OA\Property(property: 'key', type: 'string', maxLength: 64, pattern: '^[a-z0-9][a-z0-9-]*$'),
+        new OA\Property(property: 'name', type: 'string', maxLength: 255),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'is_enabled', type: 'boolean', nullable: true),
+        new OA\Property(
+            property: 'variants',
+            type: 'array',
+            minItems: 1,
+            nullable: true,
+            items: new OA\Items(ref: '#/components/schemas/FlagVariant')
+        ),
+        new OA\Property(
+            property: 'rules',
+            type: 'array',
+            nullable: true,
+            items: new OA\Items(ref: '#/components/schemas/FlagRule')
+        ),
+    ],
+    description: 'Payload for updating a flag.'
+)]
+final class DomainSchemas {}

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "test": "vendor/bin/pest",
         "lint": "vendor/bin/pint --test",
         "lint:fix": "vendor/bin/pint",
-        "stan": "php scripts/phpstan.php analyse --configuration=phpstan.neon"
+        "stan": "php scripts/phpstan.php analyse --configuration=phpstan.neon",
+        "openapi:generate": "@php api/swagger.php docs/openapi.json"
     },
     "autoload": {
         "psr-4": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -66,10 +66,2015 @@
                     }
                 }
             }
+        },
+        "/v1/projects": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "List projects",
+                "description": "List projects with pagination support.",
+                "operationId": "listProjects",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number to retrieve.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Number of results per page (1-100).",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of projects.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Create a project",
+                "description": "Store a newly created project.",
+                "operationId": "createProject",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Project created.",
+                        "headers": {
+                            "Location": {
+                                "description": "URI of the created project.",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}": {
+            "get": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Fetch a project",
+                "description": "Display the specified project.",
+                "operationId": "getProject",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Project details.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Replace a project",
+                "operationId": "replaceProject",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Project updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Delete a project",
+                "description": "Remove the specified project.",
+                "operationId": "deleteProject",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Project deleted."
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Update a project",
+                "description": "Update the specified project.",
+                "operationId": "updateProject",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Project updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}/environments": {
+            "get": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "List environments for a project",
+                "description": "List environments for the given project.",
+                "operationId": "listProjectEnvironments",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number to retrieve.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Number of results per page (1-100).",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of environments.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnvironmentCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Create an environment for a project",
+                "description": "Store a newly created environment.",
+                "operationId": "createProjectEnvironment",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Environment created.",
+                        "headers": {
+                            "Location": {
+                                "description": "URI of the created environment.",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnvironmentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}/environments/{environment}": {
+            "get": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Fetch an environment",
+                "description": "Display the specified environment.",
+                "operationId": "getProjectEnvironment",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "description": "Environment key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Environment details.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnvironmentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Environment or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Replace an environment",
+                "operationId": "replaceProjectEnvironment",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "description": "Environment key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Environment updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnvironmentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Environment or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Delete an environment",
+                "description": "Remove the specified environment.",
+                "operationId": "deleteProjectEnvironment",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "description": "Environment key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Environment deleted."
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Environment or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Update an environment",
+                "description": "Update the specified environment.",
+                "operationId": "updateProjectEnvironment",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "environment",
+                        "in": "path",
+                        "description": "Environment key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Environment updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnvironmentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Environment or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}/flags": {
+            "get": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "List flags for a project",
+                "description": "List flags for the given project.",
+                "operationId": "listProjectFlags",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number to retrieve.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Number of results per page (1-100).",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of flags.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Create a flag for a project",
+                "description": "Store a newly created flag.",
+                "operationId": "createProjectFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FlagCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Flag created.",
+                        "headers": {
+                            "Location": {
+                                "description": "URI of the created flag.",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}/flags/{flag}": {
+            "get": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Fetch a flag",
+                "description": "Display the specified flag.",
+                "operationId": "getProjectFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "flag",
+                        "in": "path",
+                        "description": "Flag key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Flag details.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flag or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Replace a flag",
+                "operationId": "replaceProjectFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "flag",
+                        "in": "path",
+                        "description": "Flag key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FlagUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Flag updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flag or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Delete a flag",
+                "description": "Remove the specified flag.",
+                "operationId": "deleteProjectFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "flag",
+                        "in": "path",
+                        "description": "Flag key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Flag deleted."
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flag or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Update a flag",
+                "description": "Update the specified flag.",
+                "operationId": "updateProjectFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "description": "Project key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "flag",
+                        "in": "path",
+                        "description": "Flag key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FlagUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Flag updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication is required.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flag or project not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/auth/token": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Issue an authentication token (stub)",
+                "operationId": "issueAuthToken",
+                "responses": {
+                    "501": {
+                        "description": "Endpoint not implemented yet.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/evaluate": {
+            "get": {
+                "tags": [
+                    "Flags"
+                ],
+                "summary": "Evaluate a feature flag (stub)",
+                "operationId": "evaluateFlag",
+                "responses": {
+                    "501": {
+                        "description": "Endpoint not implemented yet.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
         "schemas": {
+            "Project": {
+                "description": "Project representation returned by the API.",
+                "required": [
+                    "id",
+                    "key",
+                    "name",
+                    "created_at",
+                    "updated_at",
+                    "environments"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "c0a8012a-7bb2-45cb-9e7a-17a4cda9e90a"
+                    },
+                    "key": {
+                        "type": "string",
+                        "example": "checkout-service"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Checkout Service"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "environments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Environment"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectResponse": {
+                "description": "Single project response envelope.",
+                "required": [
+                    "data"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Project"
+                    }
+                },
+                "type": "object"
+            },
+            "PaginationLinks": {
+                "description": "Pagination links keyed by relation name.",
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string",
+                    "nullable": true
+                }
+            },
+            "PaginationMeta": {
+                "description": "Pagination metadata returned alongside resource collections.",
+                "properties": {
+                    "current_page": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "per_page": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "total": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "last_page": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "nullable": true
+                    }
+                },
+                "type": "object",
+                "additionalProperties": {}
+            },
+            "ProjectCollection": {
+                "description": "Paginated project collection response.",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Project"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/PaginationLinks"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                },
+                "type": "object"
+            },
+            "Environment": {
+                "description": "Environment representation.",
+                "required": [
+                    "id",
+                    "key",
+                    "name",
+                    "is_default",
+                    "created_at",
+                    "updated_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_default": {
+                        "type": "boolean"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "EnvironmentResponse": {
+                "description": "Single environment response envelope.",
+                "required": [
+                    "data"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Environment"
+                    }
+                },
+                "type": "object"
+            },
+            "EnvironmentCollection": {
+                "description": "Paginated environment collection response.",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Environment"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/PaginationLinks"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                },
+                "type": "object"
+            },
+            "FlagVariant": {
+                "description": "Flag variant configuration.",
+                "required": [
+                    "key"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "example": "variant-a"
+                    },
+                    "weight": {
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 0,
+                        "nullable": true
+                    },
+                    "payload": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {}
+                    }
+                },
+                "type": "object"
+            },
+            "FlagRule": {
+                "description": "Flag evaluation rule definition.",
+                "required": [
+                    "match",
+                    "variant"
+                ],
+                "properties": {
+                    "match": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "variant": {
+                        "type": "string"
+                    },
+                    "rollout": {
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 0,
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "Flag": {
+                "description": "Flag representation.",
+                "required": [
+                    "id",
+                    "project_id",
+                    "key",
+                    "name",
+                    "is_enabled",
+                    "variants",
+                    "created_at",
+                    "updated_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_enabled": {
+                        "type": "boolean"
+                    },
+                    "variants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagVariant"
+                        }
+                    },
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagRule"
+                        },
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "FlagResponse": {
+                "description": "Single flag response envelope.",
+                "required": [
+                    "data"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/Flag"
+                    }
+                },
+                "type": "object"
+            },
+            "FlagCollection": {
+                "description": "Paginated flag collection response.",
+                "required": [
+                    "data",
+                    "links",
+                    "meta"
+                ],
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Flag"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/PaginationLinks"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectCreateRequest": {
+                "description": "Payload for creating a project.",
+                "required": [
+                    "key",
+                    "name"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "ProjectUpdateRequest": {
+                "description": "Payload for updating a project.",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "EnvironmentCreateRequest": {
+                "description": "Payload for creating an environment.",
+                "required": [
+                    "key",
+                    "name"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_default": {
+                        "type": "boolean",
+                        "nullable": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "EnvironmentUpdateRequest": {
+                "description": "Payload for updating an environment.",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_default": {
+                        "type": "boolean",
+                        "nullable": true
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "FlagCreateRequest": {
+                "description": "Payload for creating a flag.",
+                "required": [
+                    "key",
+                    "name",
+                    "variants"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_enabled": {
+                        "type": "boolean",
+                        "nullable": true
+                    },
+                    "variants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagVariant"
+                        },
+                        "minItems": 1
+                    },
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagRule"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "FlagUpdateRequest": {
+                "description": "Payload for updating a flag.",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "pattern": "^[a-z0-9][a-z0-9-]*$"
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_enabled": {
+                        "type": "boolean",
+                        "nullable": true
+                    },
+                    "variants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagVariant"
+                        },
+                        "minItems": 1,
+                        "nullable": true
+                    },
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FlagRule"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
             "ErrorViolation": {
                 "description": "Details of a single validation violation.",
                 "required": [
@@ -159,8 +2164,24 @@
     },
     "tags": [
         {
+            "name": "Projects",
+            "description": "Projects"
+        },
+        {
+            "name": "Environments",
+            "description": "Environments"
+        },
+        {
+            "name": "Flags",
+            "description": "Flags"
+        },
+        {
             "name": "System",
             "description": "System"
+        },
+        {
+            "name": "Authentication",
+            "description": "Authentication"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- annotate project, environment, and flag endpoints with swagger-php (including request/response schemas and pagination envelopes)
- add reusable OpenAPI schemas plus stubbed definitions for not-yet-implemented routes
- improve the generation workflow with `composer openapi:generate`, README guidance, and doc regeneration

## Testing
- composer lint
- composer test
- composer stan
- composer openapi:generate