### PR TITLE
Handle Codex feedback for exception summaries

### DIFF
--- a/app/Logging/ExceptionSummaryProcessor.php
+++ b/app/Logging/ExceptionSummaryProcessor.php
@@ -44,6 +44,10 @@ final class ExceptionSummaryProcessor
         }
 
         $record['message'] = $summary;
+        $contextWithoutException = $context;
+        unset($contextWithoutException['exception']);
+
+        $record['context'] = $contextWithoutException;
 
         return $record;
     }

--- a/tests/Unit/Logging/ExceptionSummaryProcessorTest.php
+++ b/tests/Unit/Logging/ExceptionSummaryProcessorTest.php
@@ -34,3 +34,26 @@ it('appends original message when different from exception message', function ()
         ->toContain('RuntimeException: Explosion')
         ->toContain('Processing payment failed');
 });
+
+it('drops the exception from context after summarizing', function (): void {
+    $processor = new ExceptionSummaryProcessor;
+
+    $exception = new RuntimeException('Out of memory');
+
+    $record = $processor([
+        'message' => 'Processing payload',
+        'context' => [
+            'exception' => $exception,
+            'job_id' => 42,
+        ],
+    ]);
+
+    expect($record)->toHaveKey('context');
+
+    expect($record['context'])
+        ->toBeArray()
+        ->not->toHaveKey('exception')
+        ->toHaveKey('job_id');
+
+    expect($record['context']['job_id'])->toBe(42);
+});


### PR DESCRIPTION
## Summary
- clear the exception context entry once the summary message is built so stack traces are not re-appended
- add a regression test confirming the processor preserves other context fields without the throwable

## Testing
- composer test

Resolves #69.