### PR TITLE
Serve OpenAPI spec from docs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ PR descriptions should also mention any migrations, environment variables, or op
 -   Swagger UI: `/docs`
 -   Postman Collection: `/postman/FeatureFlagService.postman_collection.json`
 
-Regenerate docs once you have sourced environment variables:
+Regenerate docs once you have sourced environment variables; the API endpoint will serve the generated artifact and returns a 404 if it is missing:
 
 ```bash
 composer openapi:generate

--- a/app/Http/Controllers/OpenApiController.php
+++ b/app/Http/Controllers/OpenApiController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\File;
+use OpenApi\Attributes as OA;
+use Phlag\Http\Responses\ApiErrorResponse;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+final class OpenApiController extends Controller
+{
+    #[OA\Get(
+        path: '/v1/docs/openapi.json',
+        operationId: 'getOpenApiDocument',
+        summary: 'Retrieve the OpenAPI specification JSON.',
+        tags: ['Documentation'],
+        responses: [
+            new OA\Response(
+                response: HttpResponse::HTTP_OK,
+                description: 'OpenAPI document as JSON.',
+                content: new OA\JsonContent(type: 'object')
+            ),
+            new OA\Response(
+                response: HttpResponse::HTTP_NOT_FOUND,
+                description: 'Specification artifact is not available.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: HttpResponse::HTTP_INTERNAL_SERVER_ERROR,
+                description: 'Specification artifact could not be parsed.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    public function show(): JsonResponse
+    {
+        $artifactPath = base_path('docs/openapi.json');
+
+        if (! File::exists($artifactPath)) {
+            return ApiErrorResponse::make(
+                'resource_not_found',
+                'OpenAPI specification has not been generated yet.',
+                HttpResponse::HTTP_NOT_FOUND,
+                context: ['path' => 'docs/openapi.json']
+            );
+        }
+
+        /** @var array<array-key, mixed>|null $document */
+        $document = json_decode(File::get($artifactPath), true);
+
+        if (! is_array($document)) {
+            return ApiErrorResponse::make(
+                'server_error',
+                'Failed to read the OpenAPI specification artifact.',
+                HttpResponse::HTTP_INTERNAL_SERVER_ERROR,
+                context: ['path' => 'docs/openapi.json'],
+                detail: json_last_error_msg()
+            );
+        }
+
+        $response = response()->json($document, HttpResponse::HTTP_OK, [
+            'Content-Disposition' => 'inline; filename="openapi.json"',
+        ]);
+
+        $response->headers->set(
+            'Cache-Control',
+            'no-store, no-cache, must-revalidate, max-age=0'
+        );
+
+        $lastModified = File::lastModified($artifactPath);
+        $response->headers->set(
+            'Last-Modified',
+            gmdate('D, d M Y H:i:s', $lastModified).' GMT'
+        );
+
+        return $response;
+    }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67,6 +67,47 @@
                 }
             }
         },
+        "/v1/docs/openapi.json": {
+            "get": {
+                "tags": [
+                    "Documentation"
+                ],
+                "summary": "Retrieve the OpenAPI specification JSON.",
+                "operationId": "getOpenApiDocument",
+                "responses": {
+                    "200": {
+                        "description": "OpenAPI document as JSON.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Specification artifact is not available.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Specification artifact could not be parsed.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/projects": {
             "get": {
                 "tags": [
@@ -2163,6 +2204,10 @@
         }
     },
     "tags": [
+        {
+            "name": "Documentation",
+            "description": "Documentation"
+        },
         {
             "name": "Projects",
             "description": "Projects"

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Phlag\Http\Controllers\HealthCheckController;
+use Phlag\Http\Controllers\OpenApiController;
 use Phlag\Http\Controllers\ProjectController;
 use Phlag\Http\Controllers\ProjectEnvironmentController;
 use Phlag\Http\Controllers\ProjectFlagController;
@@ -24,5 +25,6 @@ Route::prefix('v1')
 
         Route::get('/evaluate', fn () => ApiStub::notImplemented('Flag evaluation'));
 
-        Route::get('/docs/openapi.json', fn () => ApiStub::notImplemented('OpenAPI specification'));
+        Route::get('/docs/openapi.json', [OpenApiController::class, 'show'])
+            ->name('docs.openapi');
     });

--- a/tests/Feature/DocsApiTest.php
+++ b/tests/Feature/DocsApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Symfony\Component\HttpFoundation\Response;
+
+it('serves the generated OpenAPI specification as JSON', function (): void {
+    $response = $this->get('/v1/docs/openapi.json');
+
+    $response->assertOk();
+
+    $specPath = base_path('docs/openapi.json');
+    $payload = json_decode(File::get($specPath), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($response->headers->get('Content-Type'))
+        ->toContain('application/json');
+
+    expect(json_decode($response->getContent(), true, flags: JSON_THROW_ON_ERROR))
+        ->toEqual($payload);
+});
+
+it('returns a standardized error when the OpenAPI artifact is missing', function (): void {
+    $specPath = base_path('docs/openapi.json');
+    $backupPath = $specPath.'.bak';
+
+    expect(File::exists($specPath))->toBeTrue();
+
+    File::move($specPath, $backupPath);
+
+    try {
+        $this->getJson('/v1/docs/openapi.json')
+            ->assertStatus(Response::HTTP_NOT_FOUND)
+            ->assertJson([
+                'error' => [
+                    'code' => 'resource_not_found',
+                    'status' => Response::HTTP_NOT_FOUND,
+                ],
+            ]);
+    } finally {
+        if (File::exists($backupPath)) {
+            File::move($backupPath, $specPath);
+        }
+    }
+});

--- a/tests/Feature/HttpBridgeTest.php
+++ b/tests/Feature/HttpBridgeTest.php
@@ -35,5 +35,4 @@ it('marks API endpoints as not implemented yet', function (string $method, strin
 })->with([
     ['POST', '/v1/auth/token'],
     ['GET', '/v1/evaluate'],
-    ['GET', '/v1/docs/openapi.json'],
 ]);


### PR DESCRIPTION
## Summary
- add a dedicated controller that serves the generated OpenAPI artifact with cache headers
- wire `/v1/docs/openapi.json` to the new controller and document the generation workflow
- cover the endpoint with feature tests and remove the stub expectation

Fixes #64

## Testing
- `composer test`
