### PR TITLE
Deliver flag evaluation endpoint

### DIFF
--- a/app/Evaluations/EvaluationContext.php
+++ b/app/Evaluations/EvaluationContext.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Evaluations;
+
+use Phlag\Models\Environment;
+use Phlag\Models\Flag;
+use Phlag\Models\Project;
+
+/**
+ * @phpstan-type AttributeMap array<string, array<int, string>>
+ */
+final class EvaluationContext
+{
+    /**
+     * @param  AttributeMap  $attributes
+     */
+    public function __construct(
+        public readonly Project $project,
+        public readonly Environment $environment,
+        public readonly Flag $flag,
+        public readonly ?string $userIdentifier,
+        /** @var AttributeMap */
+        public readonly array $attributes,
+    ) {}
+
+    /**
+     * Prepare context attributes for persistence or API output.
+     *
+     * @return array<string, string|array<int, string>>
+     */
+    public function denormalizedAttributes(): array
+    {
+        $denormalized = [];
+
+        foreach ($this->attributes as $key => $values) {
+            $values = array_values(array_filter($values, static fn ($value): bool => $value !== ''));
+
+            if ($values === []) {
+                continue;
+            }
+
+            $denormalized[$key] = count($values) === 1 ? $values[0] : $values;
+        }
+
+        return $denormalized;
+    }
+}

--- a/app/Evaluations/EvaluationResult.php
+++ b/app/Evaluations/EvaluationResult.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Evaluations;
+
+final class EvaluationResult
+{
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    public function __construct(
+        public readonly ?string $variant,
+        public readonly string $reason,
+        public readonly int $rollout,
+        public readonly ?array $payload = null,
+        public readonly ?int $bucket = null,
+    ) {}
+
+    /**
+     * Shape payload for database persistence.
+     *
+     * @return array<string, mixed>
+     */
+    public function payloadForStorage(): array
+    {
+        $payload = [
+            'variant' => $this->variant,
+            'rollout' => $this->rollout,
+        ];
+
+        if ($this->payload !== null) {
+            $payload['payload'] = $this->payload;
+        }
+
+        if ($this->bucket !== null) {
+            $payload['bucket'] = $this->bucket;
+        }
+
+        return $payload;
+    }
+}

--- a/app/Evaluations/FlagEvaluator.php
+++ b/app/Evaluations/FlagEvaluator.php
@@ -1,0 +1,381 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Evaluations;
+
+use Phlag\Models\Flag;
+
+final class FlagEvaluator
+{
+    public function evaluate(EvaluationContext $context): EvaluationResult
+    {
+        $flag = $context->flag;
+
+        if (! $flag->is_enabled) {
+            return $this->flagDisabled($context);
+        }
+
+        $rules = $flag->rules;
+
+        if (! is_array($rules)) {
+            $rules = [];
+        }
+
+        foreach ($rules as $rule) {
+            if (! is_array($rule)) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $rule */
+            $outcome = $this->evaluateRule($context, $rule);
+
+            if ($outcome !== null) {
+                return $outcome;
+            }
+        }
+
+        return $this->defaultFallback($context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $rule
+     */
+    private function evaluateRule(EvaluationContext $context, array $rule): ?EvaluationResult
+    {
+        $matchDefinition = $rule['match'] ?? null;
+
+        if (! is_array($matchDefinition) || $matchDefinition === []) {
+            return null;
+        }
+
+        $normalizedMatch = [];
+
+        foreach ($matchDefinition as $attribute => $values) {
+            if (! is_string($attribute) || ! is_array($values)) {
+                continue;
+            }
+
+            $normalizedValues = array_values(array_filter(
+                array_map(
+                    static fn ($value): ?string => is_scalar($value) ? (string) $value : null,
+                    $values
+                ),
+                static fn (?string $value): bool => $value !== null && $value !== ''
+            ));
+
+            if ($normalizedValues === []) {
+                continue;
+            }
+
+            $normalizedMatch[$attribute] = $normalizedValues;
+        }
+
+        if ($normalizedMatch === []) {
+            return null;
+        }
+
+        /** @var array<string, array<int, string>> $match */
+        $match = $normalizedMatch;
+
+        if (! $this->matchesRule($match, $context->attributes)) {
+            return null;
+        }
+
+        $variantKey = $this->stringValue($rule['variant'] ?? null);
+
+        if ($variantKey === null) {
+            return null;
+        }
+
+        /** @var array<string, mixed>|null $definition */
+        $definition = $this->findVariantDefinition($context->flag, $variantKey);
+
+        if ($definition === null) {
+            return null;
+        }
+
+        $rollout = $this->normalizeRollout($rule['rollout'] ?? 100);
+
+        if ($rollout === 0) {
+            return null;
+        }
+
+        $primaryKey = $this->primaryMatchKey($match);
+
+        if ($rollout >= 100 || $context->userIdentifier === null || $context->userIdentifier === '') {
+            $reason = $rollout >= 100
+                ? sprintf('matched_%s', $primaryKey)
+                : sprintf('matched_%s', $primaryKey);
+
+            return $this->makeResult($definition, $variantKey, $reason, $rollout);
+        }
+
+        $bucket = $this->bucketForRollout($context, $variantKey);
+
+        if ($bucket <= $rollout) {
+            $reason = sprintf('matched_%s_rollout', $primaryKey);
+
+            return $this->makeResult($definition, $variantKey, $reason, $rollout, $bucket);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, array<int, string>>  $match
+     * @param  array<string, array<int, string>>  $attributes
+     */
+    private function matchesRule(array $match, array $attributes): bool
+    {
+        foreach ($match as $key => $expectedValues) {
+            if (! is_array($expectedValues) || $expectedValues === []) {
+                return false;
+            }
+
+            $expected = array_map(static fn ($value): string => (string) $value, $expectedValues);
+            $actual = $attributes[$key] ?? [];
+
+            if ($actual === []) {
+                return false;
+            }
+
+            if (count(array_intersect($expected, $actual)) === 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantDefinition
+     */
+    private function makeResult(array $variantDefinition, string $variantKey, string $reason, int $rollout, ?int $bucket = null): EvaluationResult
+    {
+        $payloadValue = $variantDefinition['payload'] ?? null;
+
+        /** @var array<string, mixed>|null $payload */
+        $payload = is_array($payloadValue) ? $payloadValue : null;
+
+        return new EvaluationResult(
+            variant: $variantKey,
+            reason: $reason,
+            rollout: $rollout,
+            payload: $payload,
+            bucket: $bucket
+        );
+    }
+
+    private function flagDisabled(EvaluationContext $context): EvaluationResult
+    {
+        $variant = $this->firstVariant($context->flag);
+
+        if ($variant === null) {
+            return new EvaluationResult(
+                variant: null,
+                reason: 'flag_disabled',
+                rollout: 0
+            );
+        }
+
+        $variantKey = $this->stringValue($variant['key'] ?? null);
+
+        if ($variantKey === null) {
+            return new EvaluationResult(
+                variant: null,
+                reason: 'flag_disabled',
+                rollout: 0
+            );
+        }
+
+        return $this->makeResult($variant, $variantKey, 'flag_disabled', 0);
+    }
+
+    private function defaultFallback(EvaluationContext $context): EvaluationResult
+    {
+        $variantKey = $this->selectWeightedVariant($context);
+
+        if ($variantKey === null) {
+            return new EvaluationResult(
+                variant: null,
+                reason: 'fallback_default',
+                rollout: 0
+            );
+        }
+
+        $definition = $this->findVariantDefinition($context->flag, $variantKey);
+
+        if ($definition === null) {
+            return new EvaluationResult(
+                variant: null,
+                reason: 'fallback_default',
+                rollout: 0
+            );
+        }
+
+        return $this->makeResult($definition, $variantKey, 'fallback_default', 0);
+    }
+
+    private function selectWeightedVariant(EvaluationContext $context): ?string
+    {
+        $variants = $context->flag->variants ?? [];
+
+        if (! is_array($variants) || $variants === []) {
+            return null;
+        }
+
+        /** @var array<int, array{key: string, weight: int}> $weights */
+        $weights = [];
+        $totalWeight = 0;
+
+        foreach ($variants as $variant) {
+            if (! is_array($variant)) {
+                continue;
+            }
+
+            $key = $this->stringValue($variant['key'] ?? null);
+
+            if ($key === null) {
+                continue;
+            }
+
+            $weightValue = $variant['weight'] ?? 0;
+            $weight = is_numeric($weightValue) ? (int) $weightValue : 0;
+
+            if ($weight <= 0) {
+                continue;
+            }
+
+            $weights[] = [
+                'key' => $key,
+                'weight' => $weight,
+            ];
+            $totalWeight += $weight;
+        }
+
+        if ($weights === []) {
+            $first = $this->firstVariant($context->flag);
+
+            return is_string($first['key'] ?? null) ? $first['key'] : null;
+        }
+
+        $scaled = $this->hashToScale($context, 'default', $totalWeight);
+        $running = 0;
+
+        foreach ($weights as $entry) {
+            $running += $entry['weight'];
+
+            if ($scaled <= $running) {
+                return $entry['key'];
+            }
+        }
+
+        $last = end($weights);
+
+        return is_array($last) && is_string($last['key'] ?? null) ? $last['key'] : null;
+    }
+
+    /**
+     * @param  array<string, array<int, string>>|null  $match
+     */
+    private function primaryMatchKey(?array $match): string
+    {
+        $key = $match !== null ? array_key_first($match) : null;
+
+        if (! is_string($key) || $key === '') {
+            return 'rule';
+        }
+
+        return $key;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function firstVariant(Flag $flag): ?array
+    {
+        $variants = $flag->variants ?? [];
+
+        if (! is_array($variants) || $variants === []) {
+            return null;
+        }
+
+        $candidate = $variants[0];
+
+        return is_array($candidate) ? $candidate : null;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findVariantDefinition(Flag $flag, string $variantKey): ?array
+    {
+        $variants = $flag->variants ?? [];
+
+        if (! is_array($variants)) {
+            return null;
+        }
+
+        foreach ($variants as $variant) {
+            if (! is_array($variant)) {
+                continue;
+            }
+
+            if (($variant['key'] ?? null) === $variantKey) {
+                return $variant;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeRollout(mixed $rollout): int
+    {
+        if (! is_numeric($rollout)) {
+            return 100;
+        }
+
+        $normalized = (int) $rollout;
+
+        return max(0, min(100, $normalized));
+    }
+
+    private function bucketForRollout(EvaluationContext $context, string $salt): int
+    {
+        return $this->hashToScale($context, $salt, 100);
+    }
+
+    private function hashToScale(EvaluationContext $context, string $salt, int $max): int
+    {
+        $hash = $this->hash($context, $salt);
+
+        return (int) (($hash % $max) + 1);
+    }
+
+    private function hash(EvaluationContext $context, string $salt): int
+    {
+        $parts = [
+            (string) $context->project->key,
+            (string) $context->environment->key,
+            (string) $context->flag->key,
+            $salt,
+        ];
+
+        if ($context->userIdentifier !== null && $context->userIdentifier !== '') {
+            $parts[] = $context->userIdentifier;
+        } else {
+            $parts[] = json_encode($context->attributes, JSON_THROW_ON_ERROR);
+        }
+
+        $seed = implode('|', $parts);
+        $hash = crc32($seed);
+
+        return (int) sprintf('%u', $hash);
+    }
+}

--- a/app/Http/Controllers/EvaluateFlagController.php
+++ b/app/Http/Controllers/EvaluateFlagController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
+use Phlag\Evaluations\EvaluationContext;
+use Phlag\Evaluations\FlagEvaluator;
+use Phlag\Http\Requests\EvaluateFlagRequest;
+use Phlag\Http\Resources\EvaluationResource;
+use Phlag\Http\Responses\ApiErrorResponse;
+use Phlag\Models\Environment;
+use Phlag\Models\Evaluation;
+use Phlag\Models\Flag;
+use Phlag\Models\Project;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+class EvaluateFlagController extends Controller
+{
+    public function __construct(private readonly FlagEvaluator $evaluator) {}
+
+    public function __invoke(EvaluateFlagRequest $request): JsonResponse
+    {
+        $project = Project::query()->where('key', $request->projectKey())->first();
+
+        if ($project === null) {
+            return ApiErrorResponse::make(
+                'resource_not_found',
+                'Project not found.',
+                HttpResponse::HTTP_NOT_FOUND,
+                context: ['project' => $request->projectKey()]
+            );
+        }
+
+        $environment = Environment::query()
+            ->where('project_id', $project->id)
+            ->where('key', $request->environmentKey())
+            ->first();
+
+        if ($environment === null) {
+            return ApiErrorResponse::make(
+                'resource_not_found',
+                'Environment not found.',
+                HttpResponse::HTTP_NOT_FOUND,
+                context: [
+                    'project' => $project->key,
+                    'environment' => $request->environmentKey(),
+                ]
+            );
+        }
+
+        $flag = Flag::query()
+            ->where('project_id', $project->id)
+            ->where('key', $request->flagKey())
+            ->first();
+
+        if ($flag === null) {
+            return ApiErrorResponse::make(
+                'resource_not_found',
+                'Flag not found.',
+                HttpResponse::HTTP_NOT_FOUND,
+                context: [
+                    'project' => $project->key,
+                    'flag' => $request->flagKey(),
+                ]
+            );
+        }
+
+        $context = new EvaluationContext(
+            project: $project,
+            environment: $environment,
+            flag: $flag,
+            userIdentifier: $request->userIdentifier(),
+            attributes: $request->contextAttributes(),
+        );
+
+        $result = $this->evaluator->evaluate($context);
+
+        $evaluation = Evaluation::query()->create([
+            'id' => (string) Str::uuid(),
+            'project_id' => $project->id,
+            'environment_id' => $environment->id,
+            'flag_id' => $flag->id,
+            'flag_key' => $flag->key,
+            'variant' => $result->variant,
+            'evaluation_reason' => $result->reason,
+            'user_identifier' => $context->userIdentifier,
+            'request_context' => $context->denormalizedAttributes(),
+            'evaluation_payload' => $result->payloadForStorage(),
+            'evaluated_at' => now(),
+        ]);
+
+        $resource = new EvaluationResource(
+            $evaluation,
+            $context,
+            $result,
+            $context->denormalizedAttributes()
+        );
+
+        return $resource
+            ->response()
+            ->setStatusCode(HttpResponse::HTTP_OK)
+            ->header('Cache-Control', 'private, no-store, no-cache, must-revalidate, max-age=0')
+            ->header('Vary', 'Authorization, Accept-Encoding');
+    }
+}

--- a/app/Http/Requests/EvaluateFlagRequest.php
+++ b/app/Http/Requests/EvaluateFlagRequest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EvaluateFlagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'project' => ['required', 'string', 'max:64'],
+            'env' => ['required', 'string', 'max:64'],
+            'flag' => ['required', 'string', 'max:128'],
+            'user_id' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function projectKey(): string
+    {
+        $project = $this->query('project');
+
+        if (! is_string($project)) {
+            throw new \InvalidArgumentException('Expected validated project key to be a string.');
+        }
+
+        return $project;
+    }
+
+    public function environmentKey(): string
+    {
+        $environment = $this->query('env');
+
+        if (! is_string($environment)) {
+            throw new \InvalidArgumentException('Expected validated environment key to be a string.');
+        }
+
+        return $environment;
+    }
+
+    public function flagKey(): string
+    {
+        $flag = $this->query('flag');
+
+        if (! is_string($flag)) {
+            throw new \InvalidArgumentException('Expected validated flag key to be a string.');
+        }
+
+        return $flag;
+    }
+
+    public function userIdentifier(): ?string
+    {
+        $value = $this->query('user_id');
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function contextAttributes(): array
+    {
+        $context = [];
+        $reserved = ['project', 'env', 'flag', 'user_id'];
+
+        /** @var array<string, mixed> $query */
+        $query = $this->query();
+
+        foreach ($query as $key => $value) {
+            if (! is_string($key) || in_array($key, $reserved, true)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $values = array_values(array_filter(
+                    array_map(
+                        static fn ($item): ?string => is_scalar($item) ? (string) $item : null,
+                        $value
+                    ),
+                    static fn ($item): bool => $item !== null && $item !== ''
+                ));
+
+                if ($values !== []) {
+                    $context[$key] = $values;
+                }
+
+                continue;
+            }
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $context[$key] = [(string) $value];
+            }
+        }
+
+        return $context;
+    }
+
+    /**
+     * @return array<string, string|array<int, string>>
+     */
+    public function denormalizedContext(): array
+    {
+        $denormalized = [];
+
+        foreach ($this->contextAttributes() as $key => $values) {
+            $values = array_values(array_unique($values));
+
+            if ($values === []) {
+                continue;
+            }
+
+            $denormalized[$key] = count($values) === 1 ? $values[0] : $values;
+        }
+
+        return $denormalized;
+    }
+}

--- a/app/Http/Resources/EvaluationResource.php
+++ b/app/Http/Resources/EvaluationResource.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Phlag\Evaluations\EvaluationContext;
+use Phlag\Evaluations\EvaluationResult;
+use Phlag\Models\Evaluation;
+
+/**
+ * @mixin \Phlag\Models\Evaluation
+ */
+class EvaluationResource extends JsonResource
+{
+    /**
+     * @param  array<string, string|array<int, string>>  $requestContext
+     */
+    public function __construct(
+        Evaluation $resource,
+        private readonly EvaluationContext $context,
+        private readonly EvaluationResult $result,
+        private readonly array $requestContext,
+    ) {
+        parent::__construct($resource);
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Evaluation $evaluation */
+        $evaluation = $this->resource;
+
+        $result = [
+            'variant' => $this->result->variant,
+            'reason' => $this->result->reason,
+            'rollout' => $this->result->rollout,
+        ];
+
+        if ($this->result->payload !== null) {
+            $result['payload'] = $this->result->payload;
+        }
+
+        if ($this->result->bucket !== null) {
+            $result['bucket'] = $this->result->bucket;
+        }
+
+        return [
+            'id' => $evaluation->id,
+            'project' => [
+                'id' => $this->context->project->id,
+                'key' => $this->context->project->key,
+            ],
+            'environment' => [
+                'id' => $this->context->environment->id,
+                'key' => $this->context->environment->key,
+            ],
+            'flag' => [
+                'id' => $this->context->flag->id,
+                'key' => $this->context->flag->key,
+                'is_enabled' => $this->context->flag->is_enabled,
+            ],
+            'user' => [
+                'identifier' => $this->context->userIdentifier,
+            ],
+            'context' => $this->requestContext,
+            'result' => $result,
+            'evaluated_at' => $evaluation->evaluated_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Models/Evaluation.php
+++ b/app/Models/Evaluation.php
@@ -14,6 +14,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $project_id
  * @property string $environment_id
  * @property string $flag_id
+ * @property string $flag_key
+ * @property string|null $variant
+ * @property string|null $evaluation_reason
+ * @property string|null $user_identifier
+ * @property array<string, mixed>|null $request_context
+ * @property array<string, mixed>|null $evaluation_payload
+ * @property \Illuminate\Support\Carbon|null $evaluated_at
  */
 class Evaluation extends Model
 {

--- a/app/OpenApi/Paths/EvaluationPaths.php
+++ b/app/OpenApi/Paths/EvaluationPaths.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\OpenApi\Paths;
+
+use OpenApi\Attributes as OA;
+
+final class EvaluationPaths
+{
+    #[OA\Get(
+        path: '/v1/evaluate',
+        operationId: 'evaluateFlag',
+        summary: 'Evaluate a feature flag',
+        description: 'Determines the variant to serve for a project/environment/flag combination using rollout rules and default fallbacks.',
+        tags: ['Flags'],
+        parameters: [
+            new OA\QueryParameter(
+                name: 'project',
+                description: 'Project key that owns the flag.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'env',
+                description: 'Environment key within the project.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'flag',
+                description: 'Flag key to evaluate.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'user_id',
+                description: 'Optional user identifier used for deterministic rollout bucketing.',
+                required: false,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\QueryParameter(
+                name: 'context',
+                description: 'Additional evaluation context (pass as repeated query parameters such as `?country=US&segment=beta-testers`).',
+                required: false,
+                style: 'deepObject',
+                explode: true,
+                schema: new OA\Schema(
+                    type: 'object',
+                    additionalProperties: new OA\AdditionalProperties(type: 'string', nullable: true)
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Evaluation completed successfully.',
+                content: new OA\JsonContent(ref: '#/components/schemas/FlagEvaluationResponse')
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Project, environment, or flag not found.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed for the evaluation request.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+            new OA\Response(
+                response: 500,
+                description: 'Unexpected server error.',
+                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
+            ),
+        ]
+    )]
+    public function evaluate(): void {}
+}

--- a/app/OpenApi/Paths/StubPaths.php
+++ b/app/OpenApi/Paths/StubPaths.php
@@ -21,20 +21,8 @@ final class StubPaths
             ),
         ]
     )]
-    public function token(): void {}
-
-    #[OA\Get(
-        path: '/v1/evaluate',
-        operationId: 'evaluateFlag',
-        summary: 'Evaluate a feature flag (stub)',
-        tags: ['Flags'],
-        responses: [
-            new OA\Response(
-                response: 501,
-                description: 'Endpoint not implemented yet.',
-                content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse')
-            ),
-        ]
-    )]
-    public function evaluate(): void {}
+    public function token(): void
+    {
+        // Intentionally empty; route defined via OpenAPI annotations.
+    }
 }

--- a/app/OpenApi/Schemas/DomainSchemas.php
+++ b/app/OpenApi/Schemas/DomainSchemas.php
@@ -302,4 +302,81 @@ use OpenApi\Attributes as OA;
     ],
     description: 'Payload for updating a flag.'
 )]
+#[OA\Schema(
+    schema: 'FlagEvaluationResult',
+    required: ['variant', 'reason', 'rollout'],
+    properties: [
+        new OA\Property(property: 'variant', type: 'string', nullable: true, description: 'Variant key returned by evaluation.'),
+        new OA\Property(property: 'reason', type: 'string', description: 'Why the variant was selected.'),
+        new OA\Property(property: 'rollout', type: 'integer', minimum: 0, maximum: 100, description: 'Rollout percentage used for the decision.'),
+        new OA\Property(
+            property: 'payload',
+            type: 'object',
+            nullable: true,
+            additionalProperties: new OA\AdditionalProperties,
+            description: 'Optional payload attached to the chosen variant.'
+        ),
+        new OA\Property(property: 'bucket', type: 'integer', minimum: 1, maximum: 100, nullable: true, description: 'Deterministic bucket assigned when a rollout rule applies.'),
+    ],
+    description: 'Outcome details for a flag evaluation.'
+)]
+#[OA\Schema(
+    schema: 'FlagEvaluation',
+    required: ['id', 'project', 'environment', 'flag', 'context', 'result', 'evaluated_at'],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+        new OA\Property(
+            property: 'project',
+            type: 'object',
+            required: ['id', 'key'],
+            properties: [
+                new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'key', type: 'string'),
+            ]
+        ),
+        new OA\Property(
+            property: 'environment',
+            type: 'object',
+            required: ['id', 'key'],
+            properties: [
+                new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'key', type: 'string'),
+            ]
+        ),
+        new OA\Property(
+            property: 'flag',
+            type: 'object',
+            required: ['id', 'key', 'is_enabled'],
+            properties: [
+                new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'key', type: 'string'),
+                new OA\Property(property: 'is_enabled', type: 'boolean'),
+            ]
+        ),
+        new OA\Property(
+            property: 'user',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'identifier', type: 'string', nullable: true),
+            ]
+        ),
+        new OA\Property(
+            property: 'context',
+            type: 'object',
+            additionalProperties: new OA\AdditionalProperties(type: 'string'),
+            description: 'Evaluation context echoed from the request. Values may be strings or arrays in practice.'
+        ),
+        new OA\Property(property: 'result', ref: '#/components/schemas/FlagEvaluationResult'),
+        new OA\Property(property: 'evaluated_at', type: 'string', format: 'date-time'),
+    ],
+    description: 'Resource returned after evaluating a flag.'
+)]
+#[OA\Schema(
+    schema: 'FlagEvaluationResponse',
+    required: ['data'],
+    properties: [
+        new OA\Property(property: 'data', ref: '#/components/schemas/FlagEvaluation'),
+    ],
+    description: 'Response envelope for flag evaluation results.'
+)]
 final class DomainSchemas {}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1526,16 +1526,100 @@
                 }
             }
         },
-        "/v1/auth/token": {
-            "post": {
+        "/v1/evaluate": {
+            "get": {
                 "tags": [
-                    "Authentication"
+                    "Flags"
                 ],
-                "summary": "Issue an authentication token (stub)",
-                "operationId": "issueAuthToken",
+                "summary": "Evaluate a feature flag",
+                "description": "Determines the variant to serve for a project/environment/flag combination using rollout rules and default fallbacks.",
+                "operationId": "evaluateFlag",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "query",
+                        "description": "Project key that owns the flag.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "env",
+                        "in": "query",
+                        "description": "Environment key within the project.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "flag",
+                        "in": "query",
+                        "description": "Flag key to evaluate.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Optional user identifier used for deterministic rollout bucketing.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "context",
+                        "in": "query",
+                        "description": "Additional evaluation context (pass as repeated query parameters such as `?country=US&segment=beta-testers`).",
+                        "required": false,
+                        "style": "deepObject",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        }
+                    }
+                ],
                 "responses": {
-                    "501": {
-                        "description": "Endpoint not implemented yet.",
+                    "200": {
+                        "description": "Evaluation completed successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlagEvaluationResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project, environment, or flag not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed for the evaluation request.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Unexpected server error.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1547,13 +1631,13 @@
                 }
             }
         },
-        "/v1/evaluate": {
-            "get": {
+        "/v1/auth/token": {
+            "post": {
                 "tags": [
-                    "Flags"
+                    "Authentication"
                 ],
-                "summary": "Evaluate a feature flag (stub)",
-                "operationId": "evaluateFlag",
+                "summary": "Issue an authentication token (stub)",
+                "operationId": "issueAuthToken",
                 "responses": {
                     "501": {
                         "description": "Endpoint not implemented yet.",
@@ -2112,6 +2196,151 @@
                             "$ref": "#/components/schemas/FlagRule"
                         },
                         "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "FlagEvaluationResult": {
+                "description": "Outcome details for a flag evaluation.",
+                "required": [
+                    "variant",
+                    "reason",
+                    "rollout"
+                ],
+                "properties": {
+                    "variant": {
+                        "description": "Variant key returned by evaluation.",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "reason": {
+                        "description": "Why the variant was selected.",
+                        "type": "string"
+                    },
+                    "rollout": {
+                        "description": "Rollout percentage used for the decision.",
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 0
+                    },
+                    "payload": {
+                        "description": "Optional payload attached to the chosen variant.",
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": {}
+                    },
+                    "bucket": {
+                        "description": "Deterministic bucket assigned when a rollout rule applies.",
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 1,
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "FlagEvaluation": {
+                "description": "Resource returned after evaluating a flag.",
+                "required": [
+                    "id",
+                    "project",
+                    "environment",
+                    "flag",
+                    "context",
+                    "result",
+                    "evaluated_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "project": {
+                        "required": [
+                            "id",
+                            "key"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "key": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "environment": {
+                        "required": [
+                            "id",
+                            "key"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "key": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "flag": {
+                        "required": [
+                            "id",
+                            "key",
+                            "is_enabled"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "is_enabled": {
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "user": {
+                        "properties": {
+                            "identifier": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "context": {
+                        "description": "Evaluation context echoed from the request. Values may be strings or arrays in practice.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "result": {
+                        "$ref": "#/components/schemas/FlagEvaluationResult"
+                    },
+                    "evaluated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "FlagEvaluationResponse": {
+                "description": "Response envelope for flag evaluation results.",
+                "required": [
+                    "data"
+                ],
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/FlagEvaluation"
                     }
                 },
                 "type": "object"

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Phlag\Http\Controllers\EvaluateFlagController;
 use Phlag\Http\Controllers\HealthCheckController;
 use Phlag\Http\Controllers\OpenApiController;
 use Phlag\Http\Controllers\ProjectController;
@@ -23,7 +24,8 @@ Route::prefix('v1')
 
         Route::apiResource('projects.flags', ProjectFlagController::class);
 
-        Route::get('/evaluate', fn () => ApiStub::notImplemented('Flag evaluation'));
+        Route::get('/evaluate', EvaluateFlagController::class)
+            ->name('flags.evaluate');
 
         Route::get('/docs/openapi.json', [OpenApiController::class, 'show'])
             ->name('docs.openapi');

--- a/tests/Feature/EvaluationApiTest.php
+++ b/tests/Feature/EvaluationApiTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Phlag\Models\Environment;
+use Phlag\Models\Evaluation;
+use Phlag\Models\Flag;
+use Phlag\Models\Project;
+
+beforeEach(function (): void {
+    $this->artisan('migrate:fresh')->assertExitCode(0);
+});
+
+it('evaluates a flag using rollout rules and persists the evaluation', function (): void {
+    $project = Project::query()->create([
+        'id' => (string) Str::uuid(),
+        'key' => 'checkout-service',
+        'name' => 'Checkout Service',
+    ]);
+
+    $environment = Environment::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'production',
+        'name' => 'Production',
+        'is_default' => true,
+    ]);
+
+    $flag = Flag::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'checkout-redesign',
+        'name' => 'Checkout Redesign',
+        'is_enabled' => true,
+        'variants' => [
+            ['key' => 'control', 'weight' => 40],
+            ['key' => 'variant', 'weight' => 60],
+        ],
+        'rules' => [
+            [
+                'match' => ['country' => ['US']],
+                'variant' => 'variant',
+                'rollout' => 75,
+            ],
+        ],
+    ]);
+
+    $userId = findUserIdentifier(
+        $project->key,
+        $environment->key,
+        $flag->key,
+        'variant',
+        static fn (int $bucket): bool => $bucket <= 75
+    );
+
+    $response = $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s&user_id=%s&country=US',
+        $project->key,
+        $environment->key,
+        $flag->key,
+        $userId
+    ));
+
+    $response->assertOk()
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('data.flag.key', $flag->key)
+            ->where('data.project.key', $project->key)
+            ->where('data.environment.key', $environment->key)
+            ->where('data.user.identifier', $userId)
+            ->where('data.context.country', 'US')
+            ->where('data.result.variant', 'variant')
+            ->where('data.result.reason', 'matched_country_rollout')
+            ->where('data.result.rollout', 75)
+            ->where('data.result.bucket', fn ($bucket) => is_int($bucket) && $bucket >= 1 && $bucket <= 75)
+            ->has('data.id')
+            ->has('data.evaluated_at')
+        );
+
+    expect(Evaluation::query()->count())->toBe(1);
+});
+
+it('falls back to the default variant when rollout gating is not satisfied', function (): void {
+    $project = Project::query()->create([
+        'id' => (string) Str::uuid(),
+        'key' => 'pricing-service',
+        'name' => 'Pricing Service',
+    ]);
+
+    $environment = Environment::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'staging',
+        'name' => 'Staging',
+        'is_default' => false,
+    ]);
+
+    $flag = Flag::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'dynamic-pricing',
+        'name' => 'Dynamic Pricing',
+        'is_enabled' => true,
+        'variants' => [
+            ['key' => 'control', 'weight' => 100],
+        ],
+        'rules' => [
+            [
+                'match' => ['segment' => ['beta']],
+                'variant' => 'control',
+                'rollout' => 10,
+            ],
+        ],
+    ]);
+
+    $userId = findUserIdentifier(
+        $project->key,
+        $environment->key,
+        $flag->key,
+        'control',
+        static fn (int $bucket): bool => $bucket > 10
+    );
+
+    $response = $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s&user_id=%s&segment=beta',
+        $project->key,
+        $environment->key,
+        $flag->key,
+        $userId
+    ));
+
+    $response->assertOk()
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('data.result.variant', 'control')
+            ->where('data.result.reason', 'fallback_default')
+            ->where('data.result.rollout', 0)
+            ->missing('data.result.bucket')
+        );
+});
+
+it('returns a disabled reason when the flag is turned off', function (): void {
+    $project = Project::query()->create([
+        'id' => (string) Str::uuid(),
+        'key' => 'homepage',
+        'name' => 'Homepage',
+    ]);
+
+    $environment = Environment::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'production',
+        'name' => 'Production',
+        'is_default' => true,
+    ]);
+
+    $flag = Flag::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'recommendations',
+        'name' => 'Homepage Recommendations',
+        'is_enabled' => false,
+        'variants' => [
+            ['key' => 'off', 'weight' => 100],
+        ],
+        'rules' => [],
+    ]);
+
+    $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s&country=US',
+        $project->key,
+        $environment->key,
+        $flag->key
+    ))
+        ->assertOk()
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('data.result.reason', 'flag_disabled')
+            ->where('data.result.variant', 'off')
+            ->where('data.result.rollout', 0)
+        );
+});
+
+it('returns an error when the requested environment does not exist', function (): void {
+    $project = Project::query()->create([
+        'id' => (string) Str::uuid(),
+        'key' => 'payments',
+        'name' => 'Payments',
+    ]);
+
+    Flag::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'payments-v2',
+        'name' => 'Payments V2',
+        'is_enabled' => true,
+        'variants' => [
+            ['key' => 'off', 'weight' => 100],
+        ],
+        'rules' => [],
+    ]);
+
+    $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s',
+        $project->key,
+        'non-existent',
+        'payments-v2'
+    ))
+        ->assertNotFound()
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('error.code', 'resource_not_found')
+            ->where('error.status', 404)
+        );
+});
+
+/**
+ * Select a deterministic user identifier that maps to the desired rollout bucket.
+ */
+function findUserIdentifier(string $projectKey, string $environmentKey, string $flagKey, string $variantKey, callable $predicate): string
+{
+    foreach (range(1, 1000) as $suffix) {
+        $candidate = sprintf('user-%d', $suffix);
+        $bucket = computeBucket($projectKey, $environmentKey, $flagKey, $variantKey, $candidate);
+
+        if ($predicate($bucket) === true) {
+            return $candidate;
+        }
+    }
+
+    throw new RuntimeException('Unable to locate a user identifier matching rollout requirements.');
+}
+
+/**
+ * Compute the rollout bucket for a given user/flag combination.
+ */
+function computeBucket(string $projectKey, string $environmentKey, string $flagKey, string $variantKey, string $userIdentifier): int
+{
+    $seed = implode('|', [
+        $projectKey,
+        $environmentKey,
+        $flagKey,
+        $variantKey,
+        $userIdentifier,
+    ]);
+
+    $hash = crc32($seed);
+    $numeric = (int) sprintf('%u', $hash);
+
+    return ($numeric % 100) + 1;
+}

--- a/tests/Feature/HttpBridgeTest.php
+++ b/tests/Feature/HttpBridgeTest.php
@@ -34,5 +34,4 @@ it('marks API endpoints as not implemented yet', function (string $method, strin
         );
 })->with([
     ['POST', '/v1/auth/token'],
-    ['GET', '/v1/evaluate'],
 ]);


### PR DESCRIPTION
## Summary
- expose GET `/v1/evaluate` with a dedicated `EvaluateFlagController`
- add an evaluation engine that honors rule matching, percentage rollouts, and fallbacks
- persist and serialize evaluation results, updating OpenAPI artifacts and tests

## Testing
- `composer lint`
- `composer stan`
- `composer test`
