### PR TITLE
Add Swagger UI endpoint for OpenAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The seeders provision a reusable dataset:
 | `DELETE /v1/projects/{project}/flags/{key}` | Delete flag                                     |
 | `GET /v1/evaluate`                          | Evaluate flag (`?project=&env=&flag=&user_id=`) |
 | `GET /v1/docs/openapi.json`                 | OpenAPI JSON spec                               |
+| `GET /docs`                                 | Swagger UI viewer                               |
 
 > Full examples are available in `/postman/FeatureFlagService.postman_collection.json`.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -108,6 +108,23 @@
                 }
             }
         },
+        "/docs": {
+            "get": {
+                "tags": [
+                    "Documentation"
+                ],
+                "summary": "Render Swagger UI backed by the generated OpenAPI spec.",
+                "operationId": "getSwaggerUi",
+                "responses": {
+                    "200": {
+                        "description": "Swagger UI HTML response.",
+                        "content": {
+                            "text/html": {}
+                        }
+                    }
+                }
+            }
+        },
         "/v1/projects": {
             "get": {
                 "tags": [

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use Phlag\Http\Controllers\ProjectFlagController;
 use Phlag\Http\Responses\ApiStub;
 
 Route::get('/', HealthCheckController::class);
+Route::get('/docs', [OpenApiController::class, 'ui'])->name('docs.ui');
 
 Route::prefix('v1')
     ->middleware('api')

--- a/tests/Feature/DocsApiTest.php
+++ b/tests/Feature/DocsApiTest.php
@@ -43,3 +43,13 @@ it('returns a standardized error when the OpenAPI artifact is missing', function
         }
     }
 });
+
+it('renders Swagger UI backed by the generated spec', function (): void {
+    $response = $this->get('/docs');
+
+    $response->assertOk();
+    $response->assertSee('/v1/docs/openapi.json', false);
+
+    expect($response->headers->get('Content-Type'))
+        ->toContain('text/html');
+});


### PR DESCRIPTION
## Summary
- expose a `/docs` route that renders Swagger UI backed by the generated spec
- generate swagger-php annotations so the HTML viewer is part of the OpenAPI contract
- document the new endpoint and cover it with a feature test

## Testing
- `composer test`

Closes #13.