### PR TITLE
Wire cache:warm CLI with Redis evaluation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Database seeding completed.
 ./scripts/app-cache-warm demo-project production
 ```
 
-Provide the project and environment keys to repopulate Redis after changing flag rules. Pass additional options (for example, `--daemon`) and they are forwarded to the underlying `cache:warm` command.
+Provide the project and environment keys to repopulate Redis after changing flag rules. The warmer regenerates the snapshot stored at `flag:snapshot:{project}:{environment}` and replays historical evaluations to seed the per-user cache keys so the next request hits Redis instead of Postgres. Pass additional options (for example, `--daemon`) and they are forwarded to the underlying `cache:warm` command.
 
 #### Tune Redis cache TTLs
 

--- a/app/Commands/Cache/WarmCommand.php
+++ b/app/Commands/Cache/WarmCommand.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Commands\Cache;
+
+use LaravelZero\Framework\Commands\Command;
+use Phlag\Evaluations\Cache\FlagCacheRepository;
+use Phlag\Evaluations\Cache\FlagSignatureHasher;
+use Phlag\Evaluations\Cache\FlagSnapshotFactory;
+use Phlag\Evaluations\EvaluationContext;
+use Phlag\Evaluations\EvaluationResult;
+use Phlag\Evaluations\FlagEvaluator;
+use Phlag\Models\Environment;
+use Phlag\Models\Evaluation;
+use Phlag\Models\Flag;
+use Phlag\Models\Project;
+
+final class WarmCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'cache:warm
+                            {project : The project key to warm}
+                            {environment : The environment key to warm}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Hydrate Redis snapshot and evaluation caches for a project environment.';
+
+    public function __construct(
+        private readonly FlagCacheRepository $cacheRepository,
+        private readonly FlagSnapshotFactory $snapshotFactory,
+        private readonly FlagEvaluator $evaluator,
+        private readonly FlagSignatureHasher $signatureHasher
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $projectArgument = $this->argument('project');
+        $environmentArgument = $this->argument('environment');
+
+        if (! is_string($projectArgument) || $projectArgument === '') {
+            $this->error('The project key must be a non-empty string.');
+
+            return self::FAILURE;
+        }
+
+        if (! is_string($environmentArgument) || $environmentArgument === '') {
+            $this->error('The environment key must be a non-empty string.');
+
+            return self::FAILURE;
+        }
+
+        $projectKey = $projectArgument;
+        $environmentKey = $environmentArgument;
+
+        $project = Project::query()->where('key', $projectKey)->first();
+
+        if ($project === null) {
+            $this->error(sprintf('Project [%s] not found.', $projectKey));
+
+            return self::FAILURE;
+        }
+
+        $environment = Environment::query()
+            ->where('project_id', $project->id)
+            ->where('key', $environmentKey)
+            ->first();
+
+        if ($environment === null) {
+            $this->error(sprintf(
+                'Environment [%s] not found for project [%s].',
+                $environmentKey,
+                $projectKey
+            ));
+
+            return self::FAILURE;
+        }
+
+        $flags = Flag::query()
+            ->where('project_id', $project->id)
+            ->get();
+
+        if ($flags->isEmpty()) {
+            $this->warn(sprintf(
+                'No flags found for project [%s]; snapshot cache warmed without flag entries.',
+                $projectKey
+            ));
+        }
+
+        $snapshot = $this->snapshotFactory->make($project, $environment, $flags);
+        $this->cacheRepository->storeSnapshot($project->key, $environment->key, $snapshot);
+
+        $evaluations = Evaluation::query()
+            ->where('project_id', $project->id)
+            ->where('environment_id', $environment->id)
+            ->orderBy('evaluated_at')
+            ->get();
+
+        $flagsById = $flags->keyBy('id');
+        $warmedEvaluations = 0;
+
+        foreach ($evaluations as $evaluation) {
+            if (! is_string($evaluation->flag_id) || $evaluation->flag_id === '') {
+                continue;
+            }
+
+            $flag = $flagsById->get($evaluation->flag_id);
+
+            if (! $flag instanceof Flag) {
+                continue;
+            }
+
+            /** @var array<string, mixed>|null $requestContext */
+            $requestContext = $evaluation->request_context;
+            $attributes = $this->normalizeAttributes($requestContext);
+
+            /** @var string|null $userIdentifier */
+            $userIdentifier = $evaluation->user_identifier;
+
+            $context = new EvaluationContext(
+                project: $project,
+                environment: $environment,
+                flag: $flag,
+                userIdentifier: $userIdentifier,
+                attributes: $attributes
+            );
+
+            $result = $this->evaluator->evaluate($context);
+            $cachePayload = $this->cachePayload($result);
+            $flagSignature = $this->signatureHasher->hash($flag);
+
+            $this->cacheRepository->storeEvaluation(
+                $project->key,
+                $environment->key,
+                $flag->key,
+                $context->userIdentifier,
+                $attributes,
+                $cachePayload,
+                $flagSignature
+            );
+
+            $warmedEvaluations++;
+        }
+
+        $this->info(sprintf(
+            'Snapshot cache populated for project [%s] environment [%s].',
+            $projectKey,
+            $environmentKey
+        ));
+
+        $this->info(sprintf(
+            'Seeded %d evaluation cache entr%s based on historical evaluations.',
+            $warmedEvaluations,
+            $warmedEvaluations === 1 ? 'y' : 'ies'
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $context
+     * @return array<string, array<int, string>>
+     */
+    private function normalizeAttributes(?array $context): array
+    {
+        if (! is_array($context) || $context === []) {
+            return [];
+        }
+
+        $attributes = [];
+
+        foreach ($context as $key => $value) {
+            if (! is_string($key) || $key === '') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $values = array_values(array_filter(
+                    array_map(
+                        static fn ($item): ?string => is_scalar($item) ? (string) $item : null,
+                        $value
+                    ),
+                    static fn (?string $item): bool => $item !== null && $item !== ''
+                ));
+
+                if ($values !== []) {
+                    $attributes[$key] = $values;
+                }
+
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $stringValue = (string) $value;
+
+                if ($stringValue !== '') {
+                    $attributes[$key] = [$stringValue];
+                }
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @return array{
+     *     variant: string|null,
+     *     reason: string,
+     *     rollout: int,
+     *     payload?: array<string, mixed>,
+     *     bucket?: int
+     * }
+     */
+    private function cachePayload(EvaluationResult $result): array
+    {
+        $payload = [
+            'variant' => $result->variant,
+            'reason' => $result->reason,
+            'rollout' => $result->rollout,
+        ];
+
+        if ($result->payload !== null) {
+            $payload['payload'] = $result->payload;
+        }
+
+        if ($result->bucket !== null) {
+            $payload['bucket'] = $result->bucket;
+        }
+
+        return $payload;
+    }
+}

--- a/app/Evaluations/Cache/FlagSignatureHasher.php
+++ b/app/Evaluations/Cache/FlagSignatureHasher.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlag\Evaluations\Cache;
+
+use Phlag\Models\Flag;
+
+final class FlagSignatureHasher
+{
+    public function hash(Flag $flag): string
+    {
+        $payload = [
+            'updated_at' => $flag->updated_at?->toISOString(),
+            'is_enabled' => (bool) $flag->is_enabled,
+            'variants' => $flag->variants,
+            'rules' => $flag->rules,
+        ];
+
+        try {
+            $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return hash('sha1', serialize($payload));
+        }
+
+        return hash('sha1', $encoded);
+    }
+}

--- a/doc/adr/0011-invalidate-redis-caches.md
+++ b/doc/adr/0011-invalidate-redis-caches.md
@@ -15,7 +15,7 @@ Flag evaluation must stay fast while reflecting project changes within seconds. 
 -   Model cache entries with deterministic keys and shared TTLs. Snapshots live at `flag:snapshot:{project}:{environment}` and user-specific evaluations at `flag:evaluation:{project}:{environment}:{flag}:{signature}:{hash}`. All structures are JSON-encoded strings with a default TTL of five minutes (300 seconds).
 -   Maintain a lightweight index per environment at `flag:evaluation:index:{project}:{environment}` to delete cached evaluations without scanning Redis when mutations occur. The index expires alongside the evaluation entries.
 -   When flags, projects, or environments change, the domain layer publishes an event to the Redis channel `phlag.flags.invalidated` containing the affected project and environment identifiers. Listeners delete matching keys (`DEL`) and optionally trigger eager rebuilds.
--   The `cache:warm {project} {env}` CLI command subscribes to the same message bus when running in daemon mode. It precomputes snapshots after deploys and offers operators a manual way to refresh caches without restarting services.
+-   The `cache:warm {project} {env}` CLI command subscribes to the same message bus when running in daemon mode. It precomputes snapshots after deploys, replays historical evaluations to seed the user-scoped cache entries, and offers operators a manual way to refresh caches without restarting services.
 -   HTTP workers subscribe to the invalidation channel during boot. On receipt, they evict in-memory copies and allow the next request to repopulate Redis, ensuring horizontally scaled replicas stay in sync.
 
 ### Key schema and payloads

--- a/tests/Feature/CacheWarmCommandTest.php
+++ b/tests/Feature/CacheWarmCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use Phlag\Evaluations\Cache\FlagCacheRepository;
+use Phlag\Evaluations\Cache\FlagSignatureHasher;
+use Phlag\Models\Environment;
+use Phlag\Models\Flag;
+use Phlag\Models\Project;
+
+beforeEach(function (): void {
+    $this->artisan('migrate:fresh')->assertExitCode(0);
+});
+
+it('warms snapshot and evaluation caches for a project environment', function (): void {
+    $project = Project::query()->create([
+        'id' => (string) Str::uuid(),
+        'key' => 'search',
+        'name' => 'Search Service',
+    ]);
+
+    $environment = Environment::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'production',
+        'name' => 'Production',
+        'is_default' => true,
+    ]);
+
+    $flag = Flag::query()->create([
+        'id' => (string) Str::uuid(),
+        'project_id' => $project->id,
+        'key' => 'search-results',
+        'name' => 'Search Results v2',
+        'is_enabled' => true,
+        'variants' => [
+            ['key' => 'control', 'weight' => 100],
+        ],
+        'rules' => [],
+    ]);
+
+    $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s&locale=en-US',
+        $project->key,
+        $environment->key,
+        $flag->key
+    ))->assertOk();
+
+    /** @var FlagCacheRepository $repository */
+    $repository = app(FlagCacheRepository::class);
+    $repository->forgetSnapshot($project->key, $environment->key);
+    $repository->forgetEvaluations($project->key, $environment->key);
+
+    expect($repository->getSnapshot($project->key, $environment->key))->toBeNull();
+
+    /** @var FlagSignatureHasher $signatureHasher */
+    $signatureHasher = app(FlagSignatureHasher::class);
+    $flagSignature = $signatureHasher->hash($flag);
+
+    $evaluationAttributes = ['locale' => ['en-US']];
+
+    expect($repository->getEvaluation(
+        $project->key,
+        $environment->key,
+        $flag->key,
+        null,
+        $evaluationAttributes,
+        $flagSignature
+    ))->toBeNull();
+
+    $this->artisan('cache:warm', [
+        'project' => $project->key,
+        'environment' => $environment->key,
+    ])->assertExitCode(0);
+
+    $snapshot = $repository->getSnapshot($project->key, $environment->key);
+
+    expect($snapshot)
+        ->not->toBeNull()
+        ->and($snapshot['project']['key'] ?? null)->toBe($project->key)
+        ->and($snapshot['environment']['key'] ?? null)->toBe($environment->key);
+
+    $cachedEvaluation = $repository->getEvaluation(
+        $project->key,
+        $environment->key,
+        $flag->key,
+        null,
+        $evaluationAttributes,
+        $flagSignature
+    );
+
+    expect($cachedEvaluation)
+        ->not->toBeNull()
+        ->and($cachedEvaluation['variant'] ?? null)->toBe('control')
+        ->and($cachedEvaluation['reason'] ?? null)->toBe('fallback_default')
+        ->and($cachedEvaluation['rollout'] ?? null)->toBe(0);
+
+    $evaluationKey = (fn (
+        string $projectKey,
+        string $environmentKey,
+        string $flagKey,
+        ?string $userIdentifier,
+        array $attributes,
+        ?string $signature = null
+    ) => $this->evaluationKey($projectKey, $environmentKey, $flagKey, $userIdentifier, $attributes, $signature))
+        ->call($repository, $project->key, $environment->key, $flag->key, null, $evaluationAttributes, $flagSignature);
+
+    $evaluationStore = (fn () => $this->arrayEvaluations)->call($repository);
+    $initialEntry = $evaluationStore[$evaluationKey] ?? null;
+
+    expect($initialEntry)->not->toBeNull();
+
+    sleep(1);
+
+    $this->getJson(sprintf(
+        '/v1/evaluate?project=%s&env=%s&flag=%s&locale=en-US',
+        $project->key,
+        $environment->key,
+        $flag->key
+    ))
+        ->assertOk()
+        ->assertJson(fn ($json) => $json
+            ->where('data.flag.key', $flag->key)
+            ->where('data.result.variant', 'control')
+            ->where('data.result.reason', 'fallback_default')
+        );
+
+    $postEvaluationStore = (fn () => $this->arrayEvaluations)->call($repository);
+    $postEntry = $postEvaluationStore[$evaluationKey] ?? null;
+
+    expect($postEntry)
+        ->not->toBeNull()
+        ->and($postEntry['expires_at'] ?? null)->toBe($initialEntry['expires_at']);
+
+    app()->forgetInstance(FlagCacheRepository::class);
+});

--- a/tests/Feature/FlagCacheConfigurationTest.php
+++ b/tests/Feature/FlagCacheConfigurationTest.php
@@ -8,6 +8,8 @@ it('resolves configured TTLs from config', function (): void {
     config()->set('flag_cache.snapshot_ttl', 120);
     config()->set('flag_cache.evaluation_ttl', 240);
 
+    app()->forgetInstance(FlagCacheRepository::class);
+
     /** @var FlagCacheRepository $repository */
     $repository = app(FlagCacheRepository::class);
 


### PR DESCRIPTION
## Summary
- add a dedicated `cache:warm` command that rebuilds snapshots and replays stored evaluations into Redis
- share flag signature hashing between the HTTP evaluator and the warmer
- document the warmer behaviour and add regression coverage for hydrated caches

## Testing
- `composer lint`
- `vendor/bin/pest`
- `composer stan`
