### PR TITLE
Extend Redis cache coverage for flag evaluations

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,7 +11,11 @@
 |
 */
 
-uses(Tests\TestCase::class)->in('Feature');
+uses(
+    Tests\TestCase::class,
+    Tests\Support\InteractsWithFlagCache::class,
+    Tests\Support\RecordsDatabaseQueries::class
+)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Support/InteractsWithFlagCache.php
+++ b/tests/Support/InteractsWithFlagCache.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Phlag\Evaluations\Cache\FlagCacheRepository;
+use Phlag\Evaluations\Cache\FlagSignatureHasher;
+use Phlag\Models\Flag;
+
+trait InteractsWithFlagCache
+{
+    protected function flagCache(): FlagCacheRepository
+    {
+        return app(FlagCacheRepository::class);
+    }
+
+    protected function flagSignature(Flag $flag): string
+    {
+        /** @var FlagSignatureHasher $hasher */
+        $hasher = app(FlagSignatureHasher::class);
+
+        return $hasher->hash($flag);
+    }
+
+    /**
+     * @param  array<string, array<int, string>>  $attributes
+     * @return array<string, mixed>|null
+     */
+    protected function cachedEvaluation(
+        Flag $flag,
+        string $projectKey,
+        string $environmentKey,
+        ?string $userIdentifier,
+        array $attributes
+    ): ?array {
+        return $this->flagCache()->getEvaluation(
+            $projectKey,
+            $environmentKey,
+            $flag->key,
+            $userIdentifier,
+            $attributes,
+            $this->flagSignature($flag)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function cachedSnapshot(string $projectKey, string $environmentKey): ?array
+    {
+        return $this->flagCache()->getSnapshot($projectKey, $environmentKey);
+    }
+
+    protected function forgetFlagCaches(string $projectKey, string $environmentKey): void
+    {
+        $cache = $this->flagCache();
+        $cache->forgetSnapshot($projectKey, $environmentKey);
+        $cache->forgetEvaluations($projectKey, $environmentKey);
+    }
+}

--- a/tests/Support/RecordsDatabaseQueries.php
+++ b/tests/Support/RecordsDatabaseQueries.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Illuminate\Support\Facades\DB;
+
+trait RecordsDatabaseQueries
+{
+    /**
+     * @param  callable():void  $callback
+     * @return array<int, array<string, mixed>>
+     */
+    protected function recordDatabaseQueries(callable $callback): array
+    {
+        $connection = DB::connection();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
+
+        try {
+            $callback();
+
+            /** @var array<int, array<string, mixed>> $queries */
+            $queries = $connection->getQueryLog();
+        } finally {
+            $connection->flushQueryLog();
+            $connection->disableQueryLog();
+        }
+
+        return $queries;
+    }
+}


### PR DESCRIPTION
## Summary
- short-circuit flag evaluation when hydrated snapshots and cached results are valid
- add cache-aware test helpers and broaden coverage for cache invalidation flows
- exercise the cache:warm command against the shared repository instance to confirm it primes Redis

## Testing
- `composer test`
- `composer lint`
- `composer stan`

Resolves #79.