### PR TITLE
Enforce JWT guard across v1 routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ curl --request GET \
     ```
     Authorization: Bearer <jwt>
     ```
+-   All `/v1` project, environment, flag, and evaluation endpoints enforce the bearer guard; requests without a valid token receive the standardized `unauthenticated` error envelope.
+-   When invoking helper scripts that hit the HTTP bridge (for example, `curl` or automation workflows warming caches), forward the same bearer token so calls succeed alongside the CLI.
 -   Tokens are scoped to project + environment.
 -   Define `PHLAG_DEMO_API_KEY` before seeding to mint a demo credential for `demo-project` / `production`; rotate or remove it after validation.
 -   Responses include the bearer `token_type` plus the default roles granted to project clients so consumers can reason about access.

--- a/doc/adr/0005-adopt-jwt-bearer-auth.md
+++ b/doc/adr/0005-adopt-jwt-bearer-auth.md
@@ -21,6 +21,7 @@ Positive
 -   Stateless verification keeps the API horizontally scalable and easy to cache at the edge.
 -   JWT is widely supported by HTTP clients, SDKs, and middleware; integration friction is low.
 -   Encoded claims allow the API to make authorization decisions without additional lookups.
+-   Applying the guard to the `/v1` HTTP bridge keeps project, environment, flag, and evaluation routes aligned with CLI expectations while enforcing bearer authentication everywhere sensitive state mutates.
 
 Negative
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,6 +11,11 @@
             "description": "Local development server"
         }
     ],
+    "security": [
+        {
+            "BearerAuth": []
+        }
+    ],
     "paths": {
         "/": {
             "get": {
@@ -19,6 +24,7 @@
                 ],
                 "summary": "Retrieve service health status.",
                 "operationId": "getHealthCheck",
+                "security": [],
                 "responses": {
                     "200": {
                         "description": "Service is available.",
@@ -75,6 +81,7 @@
                 "summary": "Issue JWT from API key",
                 "description": "Exchange a project/environment API key for a JWT bearer token.",
                 "operationId": "exchangeApiKeyForJwt",
+                "security": [],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -166,6 +173,7 @@
                 ],
                 "summary": "Retrieve the OpenAPI specification JSON.",
                 "operationId": "getOpenApiDocument",
+                "security": [],
                 "responses": {
                     "200": {
                         "description": "OpenAPI document as JSON.",
@@ -1832,6 +1840,14 @@
         }
     },
     "components": {
+        "securitySchemes": {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": "JWT issued via POST /v1/auth/token."
+            }
+        },
         "schemas": {
             "Project": {
                 "description": "Project representation returned by the API.",

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,13 +21,15 @@ Route::prefix('v1')
         Route::post('/auth/token', [AuthTokenController::class, 'store'])
             ->name('auth.token');
 
-        Route::apiResource('projects', ProjectController::class);
-        Route::apiResource('projects.environments', ProjectEnvironmentController::class);
+        Route::middleware('auth.jwt')->group(function (): void {
+            Route::apiResource('projects', ProjectController::class);
+            Route::apiResource('projects.environments', ProjectEnvironmentController::class);
 
-        Route::apiResource('projects.flags', ProjectFlagController::class);
+            Route::apiResource('projects.flags', ProjectFlagController::class);
 
-        Route::get('/evaluate', EvaluateFlagController::class)
-            ->name('flags.evaluate');
+            Route::get('/evaluate', EvaluateFlagController::class)
+                ->name('flags.evaluate');
+        });
 
         Route::get('/docs/openapi.json', [OpenApiController::class, 'show'])
             ->name('docs.openapi');

--- a/tests/Feature/CacheWarmCommandTest.php
+++ b/tests/Feature/CacheWarmCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\NullOutput;
 beforeEach(function (): void {
     app()->forgetInstance(FlagCacheRepository::class);
     $this->artisan('migrate:fresh')->assertExitCode(0);
+    $this->authHeaders = jwtHeaders();
 });
 
 it('warms snapshot and evaluation caches for a project environment', function (): void {
@@ -52,7 +53,7 @@ it('warms snapshot and evaluation caches for a project environment', function ()
         $project->key,
         $environment->key,
         $flag->key
-    ))->assertOk();
+    ), $this->authHeaders)->assertOk();
 
     /** @var FlagCacheRepository $initialRepository */
     $initialRepository = app(FlagCacheRepository::class);
@@ -106,7 +107,7 @@ it('warms snapshot and evaluation caches for a project environment', function ()
             $project->key,
             $environment->key,
             $flag->key
-        ))
+        ), $this->authHeaders)
             ->assertOk()
             ->assertJson(fn ($json) => $json
                 ->where('data.flag.key', $flag->key)

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,7 +43,36 @@ expect()->extend('toBeOne', function () {
 |
 */
 
+use Phlag\Auth\Jwt\JwtTokenIssuer;
+
 function something(): void
 {
     // ..
+}
+
+/**
+ * @param  array<string, mixed>  $claims
+ * @return array<string, string>
+ */
+function jwtHeaders(array $claims = []): array
+{
+    /** @var JwtTokenIssuer $issuer */
+    $issuer = app(JwtTokenIssuer::class);
+
+    $defaultClaims = [
+        'sub' => 'test-suite',
+        'roles' => [
+            'projects.read',
+            'environments.read',
+            'flags.read',
+            'flags.evaluate',
+            'cache.warm',
+        ],
+    ];
+
+    $token = $issuer->issue(array_merge($defaultClaims, $claims));
+
+    return [
+        'Authorization' => 'Bearer '.$token->value(),
+    ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,10 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\SetRequestForConsole;
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
+use Phlag\Auth\Jwt\Configuration;
+use Phlag\Auth\Jwt\JwtTokenIssuer;
+use Phlag\Auth\Jwt\JwtTokenVerifier;
+use Tests\Support\TestKeys;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -22,6 +26,27 @@ abstract class TestCase extends BaseTestCase
         $config->set('database.default', 'sqlite');
         $config->set('database.connections.sqlite.database', ':memory:');
         $config->set('database.connections.sqlite.foreign_key_constraints', true);
+
+        $config->set('jwt', [
+            'keys' => [
+                'active' => [
+                    'id' => TestKeys::ACTIVE_KEY_ID,
+                    'private_key' => TestKeys::activePrivateKey(),
+                    'public_key' => TestKeys::activePublicKey(),
+                ],
+                'previous' => [
+                    'id' => TestKeys::PREVIOUS_KEY_ID,
+                    'public_key' => TestKeys::previousPublicKey(),
+                ],
+                'secret' => null,
+            ],
+            'ttl' => 600,
+            'clock_skew' => 0,
+        ]);
+
+        $this->app->forgetInstance(Configuration::class);
+        $this->app->forgetInstance(JwtTokenIssuer::class);
+        $this->app->forgetInstance(JwtTokenVerifier::class);
     }
 
     public function createApplication(): Application


### PR DESCRIPTION
## Summary
- protect project, environment, flag, and evaluation endpoints with the existing `auth.jwt` middleware
- update feature specs to issue JWTs automatically and cover unauthenticated behaviour
- document the JWT requirement in OpenAPI, README, and ADR 0005

## Testing
- composer test
- composer lint
- composer stan

Closes #95.